### PR TITLE
Change mode_op_map scheme to list/array

### DIFF
--- a/python/ferrmion/encode/base.py
+++ b/python/ferrmion/encode/base.py
@@ -63,7 +63,7 @@ class FermionQubitEncoding(ABC):
         """
         self.n_modes = n_modes
         self.n_qubits = n_qubits
-        self.default_mode_op_map = {i: i for i in range(self.n_modes)}
+        self.default_mode_op_map = np.array([*range(self.n_modes)], dtype=np.uint)
 
     def __eq__(self, other: object) -> bool:
         """Checks if two encodings are exactly equivalent."""
@@ -90,25 +90,23 @@ class FermionQubitEncoding(ABC):
         return self._default_mode_op_map
 
     @default_mode_op_map.setter
-    def default_mode_op_map(self, map_dict: dict[int, int]):
+    def default_mode_op_map(self, permutation: list[int]):
         """Set the default mode operator map.
 
         Args:
-            map_dict (dict[int, int]): A dictionary mapping modes to operators.
+            permutation (list[int]): A list containing a permutation of mode indices.
         """
         logger.debug("Setting default mode operator map.")
         error_string = ""
-        if set(map_dict.keys()) != {*range(self.n_modes)}:
+        if set(permutation) != {*range(self.n_modes)}:
             error_string += "Default Mode op map does not cover all modes.\n"
-        if set(map_dict.values()) != {*range(self.n_modes)}:
-            error_string += "Default Mode op map does not cover all operators.\n"
 
         if error_string != "":
             logger.error(error_string)
-            logger.error(map_dict)
+            logger.error(permutation)
             raise ValueError(error_string)
 
-        self._default_mode_op_map = map_dict
+        self._default_mode_op_map = np.array(permutation, dtype=np.uint)
 
     @property
     def vacuum_state(self):
@@ -257,7 +255,7 @@ def edge_operator(
             >>> tree.edge_operator(0,1)
     """
     logger.debug("Finding edge operator %s", edge_indices)
-    if not set(edge_indices).issubset(set(encoding.default_mode_op_map.keys())):
+    if not set(edge_indices).issubset(set(range(encoding.n_modes))):
         logger.error("Edge operator indices invalid %s", edge_indices)
         raise ValueError("Edge operator indices invalid %s", edge_indices)
 

--- a/python/tests/test_ternary_tree.py
+++ b/python/tests/test_ternary_tree.py
@@ -505,6 +505,4 @@ def test_eigenvalues_across_encodings(water_eigenvalues, water_tt, water_integra
 
 
 def test_default_mode_op_map(water_tt):
-    assert water_tt.default_mode_op_map == {
-        i: i for i in range(water_tt.n_qubits)
-    }
+    assert np.all(water_tt.default_mode_op_map == [*range(water_tt.n_qubits)])

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -68,7 +68,7 @@ fn test_symplectic_product_map() {
 pub fn hartree_fock_state(
     vacuum_state: ArrayView1<f64>,
     fermionic_hf_state: ArrayView1<bool>,
-    mode_op_map: HashMap<usize, usize>,
+    mode_op_map: ArrayView1<usize>,
     symplectic_matrix: ArrayView2<bool>,
 ) -> Result<(Array1<Complex64>, Array2<bool>)> {
     debug!("Calculating Hartree-fock state");
@@ -101,7 +101,7 @@ pub fn hartree_fock_state(
         if !occ {
             continue;
         }
-        let mode_index = mode_op_map.get(&mode).unwrap();
+        let mode_index = mode_op_map[[mode]];
 
         let left_x = x_block.index_axis(ndarray::Axis(0), 2 * mode_index);
         let right_x = x_block.index_axis(ndarray::Axis(0), 2 * mode_index + 1);
@@ -164,14 +164,7 @@ fn test_hartree_fock() {
     let vacuum_state: ArrayView1<f64> = ArrayView1::from(&[0., 0., 0., 0., 0., 0.]);
     let fermionic_hf_state: ArrayView1<bool> =
         ArrayView1::from(&[true, true, true, false, false, false]);
-    let mut mode_op_map: HashMap<usize, usize> = HashMap::new();
-    mode_op_map.insert(0, 0);
-    mode_op_map.insert(1, 1);
-    mode_op_map.insert(2, 2);
-    mode_op_map.insert(3, 3);
-    mode_op_map.insert(4, 4);
-    mode_op_map.insert(5, 5);
-    mode_op_map.insert(6, 6);
+    let mode_op_map: ArrayView1<usize> = ArrayView1::from(&[0, 1, 2, 3, 4, 5, 6]);
     let symplectic_matrix: ArrayView2<bool> = ArrayView2::from(&[
         [
             true, false, false, false, false, false, false, false, false, false, false, false,
@@ -213,7 +206,7 @@ fn test_hartree_fock() {
     let result = hartree_fock_state(
         vacuum_state,
         fermionic_hf_state,
-        mode_op_map.clone(),
+        mode_op_map,
         symplectic_matrix,
     )
     .unwrap();

--- a/src/hamiltonians.rs
+++ b/src/hamiltonians.rs
@@ -17,7 +17,7 @@ pub enum IntegralIndex {
 }
 
 pub type QubitHamiltonianTemplate = HashMap<String, HashMap<IntegralIndex, Complex64>>;
-
+pub type QubitHamiltonian<'template> = HashMap<&'template String, Complex64>;
 pub enum Notation {
     Physicist,
     Chemist,
@@ -135,13 +135,13 @@ pub fn molecular(
 //     Zip::from(sym_products.exact_chunks((n_modes, n_modes, 1))).for_each(|i| println!("{}", i));
 // }
 
-pub fn fill_template(
-    template: QubitHamiltonianTemplate,
+pub fn fill_template<'template>(
+    template: &'template QubitHamiltonianTemplate,
     constant_energy: f64,
     one_e_terms: ArrayView2<f64>,
     two_e_terms: ArrayView4<f64>,
-    mode_op_map: HashMap<usize, usize>,
-) -> HashMap<String, Complex64> {
+    mode_op_map: ArrayView1<usize>,
+) -> QubitHamiltonian<'template> {
     debug!("Filling template with mode-operator map {:#?}", mode_op_map);
     assert!(one_e_terms
         .shape()
@@ -151,44 +151,39 @@ pub fn fill_template(
         .shape()
         .iter()
         .all(|&s| s == one_e_terms.len_of(Axis(0))));
-    assert!((0..one_e_terms.len_of(Axis(0))).all(|v| { mode_op_map.contains_key(&v) }));
-    assert!(mode_op_map
-        .values()
-        .all(|v| { mode_op_map.contains_key(v) }));
+    assert!(one_e_terms.len_of(Axis(0)) == mode_op_map.len());
     // assert_eq!(HashSet::from(mode_op_map.keys()), HashSet::from(0..one_e_terms.len_of(Axis(0))));
     // assert_eq!(HashSet::from(mode_op_map.values()), (HashSet::from(0..one_e_terms.len_of(Axis(0)))));
-    let mut hamiltonian: HashMap<String, Complex64> = HashMap::new();
-    hamiltonian.insert(
-        "I".repeat(mode_op_map.len()).to_string(),
-        Complex64::new(constant_energy, 0.),
-    );
+    let mut hamiltonian: QubitHamiltonian<'template> = QubitHamiltonian::new();
+    let identity_key: String = "I".repeat(mode_op_map.len()).to_string();
+    if let Some(identity_val) = hamiltonian.get_mut(&identity_key) {
+        *identity_val += Complex64::new(constant_energy, 0.);
+    }
 
     for (pauli_term, components) in template {
-        let mut val = Complex64::new(0., 0.);
-        let err_str = "Mode op map does not contain integral index.";
-        for (indices, factor) in components {
-            let coeff = match indices {
-                IntegralIndex::OneE(m, n) => {
-                    one_e_terms[[
-                        *mode_op_map.get(&m).expect(err_str),
-                        *mode_op_map.get(&n).expect(err_str),
-                    ]]
-                }
-                IntegralIndex::TwoE(p, q, r, s) => {
-                    two_e_terms[[
-                        *mode_op_map.get(&p).expect(err_str),
-                        *mode_op_map.get(&q).expect(err_str),
-                        *mode_op_map.get(&r).expect(err_str),
-                        *mode_op_map.get(&s).expect(err_str),
-                    ]]
-                }
-            };
-            val += factor * Complex64::new(coeff, 0.);
-        }
+        let val = components
+            .iter()
+            .fold(Complex64::new(0., 0.), |acc, (indices, factor)| {
+                let coeff = match indices {
+                    IntegralIndex::TwoE(p, q, r, s) => {
+                        two_e_terms[[
+                            mode_op_map[[*p]],
+                            mode_op_map[[*q]],
+                            mode_op_map[[*r]],
+                            mode_op_map[[*s]],
+                        ]]
+                    }
+                    IntegralIndex::OneE(m, n) => {
+                        one_e_terms[[mode_op_map[[*m]], mode_op_map[[*n]]]]
+                    }
+                };
+                acc + factor * Complex64::new(coeff, 0.)
+            });
         if val.norm() > 1e-12 {
             hamiltonian.insert(pauli_term, val);
         };
     }
+
     debug!(
         "Template filled: hamiltonian.keys()={:?}",
         hamiltonian.keys()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ fn core(m: &Bound<'_, PyModule>) -> PyResult<()> {
         py: Python<'py>,
         vacuum_state: PyReadonlyArray1<f64>,
         fermionic_hf_state: PyReadonlyArray1<bool>,
-        mode_op_map: Bound<'py, PyDict>,
+        mode_op_map: PyReadonlyArray1<usize>,
         symplectic_matrix: PyReadonlyArray2<bool>,
     ) -> (Bound<'py, PyArray1<Complex64>>, Bound<'py, PyArray2<bool>>) {
         /*
@@ -73,15 +73,12 @@ fn core(m: &Bound<'_, PyModule>) -> PyResult<()> {
         */
         let vacuum_state = vacuum_state.as_array();
         let fermionic_hf_state = fermionic_hf_state.as_array();
-        let rust_mode_op_map: HashMap<usize, usize> = match mode_op_map.extract() {
-            Ok(hashmap) => hashmap,
-            Err(_) => panic!("Mode op map cannot be parsed as HashMap."),
-        };
+        let mode_op_map = mode_op_map.as_array();
         let symplectic_matrix = symplectic_matrix.as_array();
         let (coeffs, states) = hartree_fock_state(
             vacuum_state,
             fermionic_hf_state,
-            rust_mode_op_map,
+            mode_op_map,
             symplectic_matrix,
         )
         .unwrap();
@@ -178,16 +175,16 @@ fn core(m: &Bound<'_, PyModule>) -> PyResult<()> {
         constant_energy: f64,
         one_e_terms: PyReadonlyArray2<f64>,
         two_e_terms: PyReadonlyArray4<f64>,
-        mode_op_map: Py<PyDict>,
+        mode_op_map: PyReadonlyArray1<usize>,
     ) -> PyResult<Bound<'py, PyDict>> {
         // let constant_energy = constant_energy.extract(py)?;
-        let mode_op_map = mode_op_map.extract::<HashMap<usize, usize>>(py)?;
+        let mode_op_map = mode_op_map.as_array();
         let template =
             template.extract::<HashMap<String, HashMap<IntegralIndex, Complex64>>>(py)?;
         let one_e_terms = one_e_terms.as_array();
         let two_e_terms = two_e_terms.as_array();
         let hamiltonian = fill_template(
-            template,
+            &template,
             constant_energy,
             one_e_terms,
             two_e_terms,


### PR DESCRIPTION
Currently the mode to operator map is a dict, containing ints in range(n_modes).

Using a dict for this is silly, as the keys are just indices and the values just ints...

For optimisation of enumerations we'll need to send many permutations of the mode op maps. Building and manipulating these as a 2D array is much easier than creating a set of dicts.