### PR TITLE
fix topphatt weight bug

### DIFF
--- a/python/ferrmion/optimize/hatt.py
+++ b/python/ferrmion/optimize/hatt.py
@@ -23,7 +23,7 @@ def _qubit_term_weight(term: Iterable, comb: tuple[int, int, int]) -> int:
     Returns:
         int: Weight of the term.
     """
-    odd_parity_paulis = [sum([t != c for t in term]) % 2 for c in comb]
+    odd_parity_paulis = [sum([t == c for t in term]) % 2 for c in comb]
     non_commuting = sum(odd_parity_paulis) % 3
     return int(non_commuting != 0)
 
@@ -273,7 +273,7 @@ def fast_hatt(
                         continue
                     else:
                         odd_parity_paulis = [
-                            sum([t != c for t in key]) % 2 for c in comb
+                            sum([t == c for t in key]) % 2 for c in comb
                         ]
                         non_commuting = sum(odd_parity_paulis) % 3
                         weight += int(non_commuting != 0)
@@ -288,7 +288,7 @@ def fast_hatt(
                         continue
                     else:
                         odd_parity_paulis = [
-                            sum([t != c for t in key]) % 2 for c in comb
+                            sum([t == c for t in key]) % 2 for c in comb
                         ]
                         non_commuting = sum(odd_parity_paulis) % 3
                         weight += int(non_commuting != 0)

--- a/python/ferrmion/optimize/topphatt.py
+++ b/python/ferrmion/optimize/topphatt.py
@@ -401,7 +401,7 @@ def topphatt(
                         continue
                     else:
                         odd_parity_paulis = [
-                            sum([t != c for t in key]) % 2 for c in comb
+                            sum([t == c for t in key]) % 2 for c in comb
                         ]
                         non_commuting = sum(odd_parity_paulis) % 3
                         weight += int(non_commuting != 0)


### PR DESCRIPTION
When calculating the weight of terms in hatt and topphatt, there was a bug causing odd-length majorana terms to return the incorrect weight.