### PR TITLE
Remove pydata_sphinx_theme from extensions to fix Sphinx 9.x build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,7 +32,6 @@ extensions = ["sphinx.ext.autodoc",
     # "sphinx.ext.githubpages",
     "sphinx.ext.napoleon",
     "myst_nb",
-    "pydata_sphinx_theme",
     "myst_sphinx_gallery",
     ]
 


### PR DESCRIPTION
Having pydata_sphinx_theme in extensions caused its setup() to be called
before app.builder was initialized (Sphinx 9.1.0 behavior), triggering
AttributeError. The theme is already loaded correctly via html_theme.

https://claude.ai/code/session_01NfHKuAKELn5Q1oAsBXPoL6