### PR TITLE
Add ZBasisEnsemble type and batch decode method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,10 +110,110 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -118,6 +239,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "either"
@@ -147,7 +274,8 @@ version = "0.7.3"
 dependencies = [
  "ahash",
  "argmin",
- "itertools",
+ "criterion",
+ "itertools 0.14.0",
  "log",
  "ndarray",
  "num-complex",
@@ -193,6 +321,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,12 +362,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -258,6 +433,12 @@ dependencies = [
  "autocfg",
  "rawpointer",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
@@ -344,10 +525,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -610,6 +825,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +888,58 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -723,6 +1013,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +1062,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,6 +1084,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -816,3 +1190,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,11 @@ num_cpus = "1.17.0"
 
 [dev-dependencies]
 proptest = "1.9.0"
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "decode_zbasis_ensemble"
+harness = false
 
 [profile.profiling]
 inherits = "release"

--- a/benches/decode_zbasis_ensemble.rs
+++ b/benches/decode_zbasis_ensemble.rs
@@ -1,0 +1,62 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use ferrmion::encode::encoding::{MajoranaEncoding, TryEncode};
+use ferrmion::encode::ternarytree::TernaryTree;
+use ferrmion::states::{FockState, ZBasisEnsemble, ZBasisState};
+use ndarray::Array1;
+use num_complex::Complex64;
+
+fn make_ensemble(encoding: &MajoranaEncoding, n_states: usize) -> ZBasisEnsemble {
+    let n_modes = encoding.n_modes;
+    let total_states = 1 << n_modes;
+    let states: Vec<ZBasisState> = (0..n_states)
+        .map(|i| {
+            let bits = i % total_states;
+            let occ: Vec<bool> = (0..n_modes).map(|j| (bits >> j) & 1 != 0).collect();
+            let fock = FockState::new(Array1::from(occ), Complex64::ONE);
+            encoding.try_encode(fock).unwrap().unwrap()
+        })
+        .collect();
+    ZBasisEnsemble::from(states)
+}
+
+fn bench_decode_ensemble(c: &mut Criterion) {
+    let n_modes = 4;
+    let tree = TernaryTree::naive_jordan_wigner(n_modes);
+    let encoding = tree.build_encoding(n_modes).unwrap();
+
+    let mut group = c.benchmark_group("decode_zbasis_ensemble");
+
+    for n_states in [10usize, 100, 1000] {
+        let ensemble = make_ensemble(&encoding, n_states);
+
+        group.bench_with_input(
+            BenchmarkId::new("batch_parallel", n_states),
+            &n_states,
+            |b, _| {
+                b.iter(|| encoding.decode_zbasis_ensemble(black_box(&ensemble)));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("sequential", n_states),
+            &n_states,
+            |b, _| {
+                b.iter(|| {
+                    ensemble
+                        .states
+                        .axis_iter(ndarray::Axis(0))
+                        .zip(ensemble.coefficients.iter())
+                        .map(|(row, &coeff)| {
+                            encoding.decode_zbasis_state(ZBasisState::new(row.to_owned(), coeff))
+                        })
+                        .collect::<Vec<_>>()
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_decode_ensemble);
+criterion_main!(benches);

--- a/python/ferrmion/core.pyi
+++ b/python/ferrmion/core.pyi
@@ -91,3 +91,9 @@ def fermionic_to_sparse_majorana(
     coeffs: list[np.ndarray],
     constant_energy: float,
 ) -> dict: ...
+def decode(
+    states: npt.NDArray[np.bool],
+    ipowers: npt.NDArray[np.uint8],
+    symplectic_matrix: npt.NDArray[np.bool],
+    vacuum_state: npt.NDArray[np.bool],
+) -> npt.NDArray[np.bool]: ...

--- a/python/ferrmion/encode/base.py
+++ b/python/ferrmion/encode/base.py
@@ -9,6 +9,7 @@ from numpy.typing import ArrayLike, NDArray
 
 from ferrmion.core import (
     anneal_enumerations,
+    decode,
     encode,
     encode_fermion_product,
 )
@@ -234,6 +235,30 @@ class FermionQubitEncoding(ABC):
             signatures=signatures,
             coeffs=coeffs,
             constant_energy=fham.constant_energy,
+        )
+
+    def decode(self, states: NDArray[np.bool]) -> NDArray[np.bool]:
+        """Decode Z-basis states into fermionic occupation vectors.
+
+        Decodes all rows of ``states`` in a single batch call to the Rust
+        implementation, which processes each annihilation operator across every
+        row before advancing to the next mode.
+
+        Args:
+            states: 2D boolean array of shape ``(n_states, n_qubits)``.
+
+        Returns:
+            2D boolean array of shape ``(n_states, n_modes)``.
+
+        Raises:
+            ValueError: if any state cannot be decoded for this encoding.
+        """
+        ipow, sym = self._build_symplectic_matrix()
+        return decode(
+            states=states,
+            ipowers=ipow,
+            symplectic_matrix=sym,
+            vacuum_state=self.vacuum_state.astype(bool),
         )
 
     @staticmethod

--- a/python/tests/test_ternary_tree.py
+++ b/python/tests/test_ternary_tree.py
@@ -570,6 +570,18 @@ def test_benchmark_hartree_fock_state(benchmark, encoding,n_modes):
     benchmark(lambda: tree.hartree_fock_state(fermionic_hf_state=fermionic_hf_state))
 
 
+@pytest.mark.parametrize("encoding", [JW, PE, BK, JKMN])
+@pytest.mark.parametrize("n_modes", [32, 64, 128])
+def test_benchmark_decode_zbasis_ensemble(benchmark, encoding, n_modes):
+    fermionic_hf_state = np.ones(n_modes, dtype=np.bool)
+    tree: TernaryTree = encoding(n_modes)
+    tree.enumeration_scheme = tree.default_enumeration_scheme()
+    qubit_state = tree.hartree_fock_state(fermionic_hf_state=fermionic_hf_state)
+    # Build an ensemble of 100 identical states.
+    states = np.tile(qubit_state, (100, 1))
+    benchmark(lambda: tree.decode(states))
+
+
 @st.composite
 def tt_flatpack_strategy(draw, n_nodes_strategy):
     n_nodes = draw(n_nodes_strategy)

--- a/src/encode/encoding.rs
+++ b/src/encode/encoding.rs
@@ -1121,20 +1121,27 @@ mod owned_tests {
 
     #[test]
     fn test_decode_ensemble_matches_single_decode() {
-        let tree = TernaryTree::naive_jordan_wigner(4);
-        let encoding = tree.build_encoding(4).unwrap();
-        let encoded_states: Vec<ZBasisState> = (0u8..16)
-            .map(|bits| {
-                let occ: Vec<bool> = (0..4).map(|i| (bits >> i) & 1 != 0).collect();
-                let fock = FockState::new(Array1::from(occ), Complex64::ONE);
-                encoding.try_encode(fock).unwrap().unwrap()
-            })
-            .collect();
-        let ensemble = ZBasisEnsemble::from(encoded_states.clone());
-        let batch_results = encoding.decode_zbasis_ensemble(&ensemble);
-        for (single_state, batch_result) in encoded_states.into_iter().zip(batch_results) {
-            let single_result = encoding.decode_zbasis_state(single_state);
-            assert_eq!(single_result.map(|s| s.state), batch_result.map(|s| s.state));
+        let trees = [
+            TernaryTree::naive_jordan_wigner(4),
+            TernaryTree::naive_parity(4),
+            TernaryTree::naive_bravyi_kitaev(4),
+            TernaryTree::naive_jkmn(4),
+        ];
+        for tree in trees {
+            let encoding = tree.build_encoding(4).unwrap();
+            let encoded_states: Vec<ZBasisState> = (0u8..16)
+                .map(|bits| {
+                    let occ: Vec<bool> = (0..4).map(|i| (bits >> i) & 1 != 0).collect();
+                    let fock = FockState::new(Array1::from(occ), Complex64::ONE);
+                    encoding.try_encode(fock).unwrap().unwrap()
+                })
+                .collect();
+            let ensemble = ZBasisEnsemble::from(encoded_states.clone());
+            let batch_results = encoding.decode_zbasis_ensemble(&ensemble);
+            for (single_state, batch_result) in encoded_states.into_iter().zip(batch_results) {
+                let single_result = encoding.decode_zbasis_state(single_state);
+                assert_eq!(single_result.map(|s| s.state), batch_result.map(|s| s.state));
+            }
         }
     }
 

--- a/src/encode/encoding.rs
+++ b/src/encode/encoding.rs
@@ -600,10 +600,8 @@ impl MajoranaEncoding {
                 .map(|j| {
                     let row = current_states.row(j);
                     let coeff = current_coeffs[j];
-                    let par_l =
-                        row.iter().zip(z_l.iter()).filter(|(&a, &b)| a && b).count() % 2;
-                    let par_r =
-                        row.iter().zip(z_r.iter()).filter(|(&a, &b)| a && b).count() % 2;
+                    let par_l = row.iter().zip(z_l.iter()).filter(|(&a, &b)| a && b).count() % 2;
+                    let par_r = row.iter().zip(z_r.iter()).filter(|(&a, &b)| a && b).count() % 2;
                     let lc = coeff * phase_l[par_l];
                     let rc = coeff * phase_r[par_r];
                     lc + Complex64::new(0., 1.) * rc
@@ -611,8 +609,10 @@ impl MajoranaEncoding {
                 .collect();
 
             // Determine which states have mode i occupied.
-            let occupied: Vec<bool> =
-                ann_coeffs.iter().map(|c: &Complex64| c.norm() > 1e-10).collect();
+            let occupied: Vec<bool> = ann_coeffs
+                .iter()
+                .map(|c: &Complex64| c.norm() > 1e-10)
+                .collect();
 
             // Update occupations and accumulated coefficients.
             for (j, (&occ, &ann)) in occupied.iter().zip(ann_coeffs.iter()).enumerate() {
@@ -638,7 +638,10 @@ impl MajoranaEncoding {
         (0..n_states)
             .map(|j| {
                 if current_states.row(j) == vacuum.view() {
-                    Some(FockState::new(occupations.row(j).to_owned(), Complex64::ONE))
+                    Some(FockState::new(
+                        occupations.row(j).to_owned(),
+                        Complex64::ONE,
+                    ))
                 } else {
                     None
                 }
@@ -1140,7 +1143,10 @@ mod owned_tests {
             let batch_results = encoding.decode_zbasis_ensemble(&ensemble);
             for (single_state, batch_result) in encoded_states.into_iter().zip(batch_results) {
                 let single_result = encoding.decode_zbasis_state(single_state);
-                assert_eq!(single_result.map(|s| s.state), batch_result.map(|s| s.state));
+                assert_eq!(
+                    single_result.map(|s| s.state),
+                    batch_result.map(|s| s.state)
+                );
             }
         }
     }

--- a/src/encode/encoding.rs
+++ b/src/encode/encoding.rs
@@ -6,13 +6,12 @@ use crate::hamiltonians::QubitHamiltonian;
 use crate::operators::{
     FermionProduct, MajoranaProduct, MajoranaSparse, SymplecticMatrix, SymplecticOperator,
 };
-use crate::states::{FockState, ZBasisState};
+use crate::states::{FockState, ZBasisEnsemble, ZBasisState};
 use crate::utils::{self, icount_to_sign};
 use ahash::RandomState;
 use log::{debug, error};
-use ndarray::Axis;
+use ndarray::{Array1, Array2, Axis, Zip};
 use num_complex::{c64, Complex64};
-use numpy::ndarray::{Array1, Array2};
 use rayon::prelude::*;
 use std::collections::HashMap;
 use thiserror::Error;
@@ -536,6 +535,116 @@ impl MajoranaEncoding {
 
         Some(FockState::new(Array1::from(occupation), Complex64::ONE))
     }
+
+    /// Decode all states in a [`ZBasisEnsemble`] into [`FockState`]s.
+    ///
+    /// Applies each fermionic annihilation operator across all rows of the ensemble
+    /// before advancing to the next mode, avoiding per-state array clones.
+    /// Input coefficients on the ensemble states are ignored; all are treated as
+    /// [`Complex64::ONE`].
+    ///
+    /// Returns `None` for any row that does not correspond to a valid encoded state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ferrmion::encode::encoding::{MajoranaEncoding, TryEncode};
+    /// use ferrmion::states::{FockState, ZBasisEnsemble};
+    /// use ferrmion::encode::ternarytree::TernaryTree;
+    /// use ndarray::Array1;
+    /// use num_complex::Complex64;
+    ///
+    /// let tree = TernaryTree::naive_jordan_wigner(3);
+    /// let encoding = tree.build_encoding(3).unwrap();
+    /// let fock = FockState::new(Array1::from(vec![true, false, true]), Complex64::ONE);
+    /// let encoded = encoding.try_encode(fock.clone()).unwrap().unwrap();
+    /// let ensemble = ZBasisEnsemble::from(vec![encoded]);
+    /// let decoded = encoding.decode_zbasis_ensemble(&ensemble);
+    /// assert_eq!(decoded[0].as_ref().unwrap().state, fock.state);
+    /// ```
+    pub fn decode_zbasis_ensemble(&self, ensemble: &ZBasisEnsemble) -> Vec<Option<FockState>> {
+        let n_states = ensemble.states.nrows();
+
+        // Working state matrix mutated in-place; coefficients start at ONE (input ignored).
+        let mut current_states = ensemble.states.clone();
+        let mut current_coeffs = Array1::from_elem(n_states, Complex64::ONE);
+        let mut occupations = Array2::<bool>::default((n_states, self.n_modes));
+
+        for i in (0..self.n_modes).rev() {
+            let x_l = self.operators.x_block.row(2 * i);
+            let z_l = self.operators.z_block.row(2 * i);
+            let ip_l = self.operators.ipowers[2 * i];
+            let x_r = self.operators.x_block.row(2 * i + 1);
+            let z_r = self.operators.z_block.row(2 * i + 1);
+            let ip_r = self.operators.ipowers[2 * i + 1];
+
+            // Validity: left and right new states must agree; this is an encoding
+            // property (x_l == x_r), not per-state.
+            if x_l != x_r {
+                return vec![None; n_states];
+            }
+
+            // Precompute the two possible phases for each operator (parity even/odd).
+            let phase_l = [
+                c64(0., 1.).powi(ip_l as i32 % 4),
+                c64(0., 1.).powi((ip_l as i32 + 2) % 4),
+            ];
+            let phase_r = [
+                c64(0., 1.).powi(ip_r as i32 % 4),
+                c64(0., 1.).powi((ip_r as i32 + 2) % 4),
+            ];
+
+            // Compute annihilation coefficients for all states in parallel.
+            let ann_coeffs: Vec<Complex64> = (0..n_states)
+                .into_par_iter()
+                .map(|j| {
+                    let row = current_states.row(j);
+                    let coeff = current_coeffs[j];
+                    let par_l =
+                        row.iter().zip(z_l.iter()).filter(|(&a, &b)| a && b).count() % 2;
+                    let par_r =
+                        row.iter().zip(z_r.iter()).filter(|(&a, &b)| a && b).count() % 2;
+                    let lc = coeff * phase_l[par_l];
+                    let rc = coeff * phase_r[par_r];
+                    lc + Complex64::new(0., 1.) * rc
+                })
+                .collect();
+
+            // Determine which states have mode i occupied.
+            let occupied: Vec<bool> =
+                ann_coeffs.iter().map(|c: &Complex64| c.norm() > 1e-10).collect();
+
+            // Update occupations and accumulated coefficients.
+            for (j, (&occ, &ann)) in occupied.iter().zip(ann_coeffs.iter()).enumerate() {
+                if occ {
+                    occupations[[j, i]] = true;
+                    current_coeffs[j] = ann;
+                }
+            }
+
+            // In-place state update for occupied rows: XOR each row with x_l.
+            let occupied_arr = Array1::from(occupied);
+            Zip::from(current_states.rows_mut())
+                .and(&occupied_arr)
+                .for_each(|mut row, &occ| {
+                    if occ {
+                        row.zip_mut_with(&x_l, |a, &b| *a ^= b);
+                    }
+                });
+        }
+
+        // Validate final state matches encoding vacuum.
+        let vacuum = &self.vacuum_state.state;
+        (0..n_states)
+            .map(|j| {
+                if current_states.row(j) == vacuum.view() {
+                    Some(FockState::new(occupations.row(j).to_owned(), Complex64::ONE))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
 }
 
 /// Attempt to encode a [`FockState`] into a [`ZBasisState`] using the Majorana encoding.
@@ -606,7 +715,7 @@ mod owned_tests {
 
     use crate::encode::ternarytree::TernaryTree;
     use crate::operators::LadderOperator;
-    use crate::states::State;
+    use crate::states::{State, ZBasisEnsemble};
     use ndarray::{arr1, Array1};
     use num_complex::c64;
     use numpy::Complex64;
@@ -1007,6 +1116,63 @@ mod owned_tests {
             let decoded = encoding.decode_zbasis_state(encoded).unwrap();
             let expected: Array1<bool> = hf_state.into_iter().collect();
             prop_assert_eq!(decoded.state, expected);
+        }
+    }
+
+    #[test]
+    fn test_decode_ensemble_matches_single_decode() {
+        let tree = TernaryTree::naive_jordan_wigner(4);
+        let encoding = tree.build_encoding(4).unwrap();
+        let encoded_states: Vec<ZBasisState> = (0u8..16)
+            .map(|bits| {
+                let occ: Vec<bool> = (0..4).map(|i| (bits >> i) & 1 != 0).collect();
+                let fock = FockState::new(Array1::from(occ), Complex64::ONE);
+                encoding.try_encode(fock).unwrap().unwrap()
+            })
+            .collect();
+        let ensemble = ZBasisEnsemble::from(encoded_states.clone());
+        let batch_results = encoding.decode_zbasis_ensemble(&ensemble);
+        for (single_state, batch_result) in encoded_states.into_iter().zip(batch_results) {
+            let single_result = encoding.decode_zbasis_state(single_state);
+            assert_eq!(single_result.map(|s| s.state), batch_result.map(|s| s.state));
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_decode_ensemble_matches_single_decode_all_encodings(
+            hf_states in proptest::collection::vec(
+                proptest::collection::vec(proptest::bool::ANY, 1..8usize),
+                1..20usize,
+            ),
+            encoding_idx in 0usize..4,
+        ) {
+            let n = hf_states[0].len();
+            // Filter to same length so they form a valid ensemble matrix.
+            let hf_states: Vec<Vec<bool>> = hf_states.into_iter().filter(|s| s.len() == n).collect();
+            prop_assume!(!hf_states.is_empty());
+            let tree = match encoding_idx {
+                0 => TernaryTree::naive_jordan_wigner(n),
+                1 => TernaryTree::naive_parity(n),
+                2 => TernaryTree::naive_bravyi_kitaev(n),
+                _ => TernaryTree::naive_jkmn(n),
+            };
+            let encoding = tree.build_encoding(n).expect("valid encoding");
+            let encoded_states: Vec<ZBasisState> = hf_states.iter()
+                .map(|occ| {
+                    let fock = FockState::new(Array1::from(occ.clone()), Complex64::ONE);
+                    encoding.try_encode(fock).unwrap().unwrap()
+                })
+                .collect();
+            let ensemble = ZBasisEnsemble::from(encoded_states.clone());
+            let batch_results = encoding.decode_zbasis_ensemble(&ensemble);
+            for (single_input, batch_result) in encoded_states.into_iter().zip(batch_results) {
+                let single_result = encoding.decode_zbasis_state(single_input);
+                prop_assert_eq!(
+                    single_result.map(|s| s.state),
+                    batch_result.map(|s| s.state)
+                );
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub mod hamiltonians;
 use crate::hamiltonians::QubitHamiltonian;
 pub mod encode;
 use crate::encode::encoding::{Encode, MajoranaEncoding, MajoranaEncodingError, TryEncode};
-use crate::states::{FockState, State, ZBasisState};
+use crate::states::{FockState, State, ZBasisEnsemble, ZBasisState};
 pub mod optimise;
 use crate::encode::maxnto::{maxnto_symplectic_matrix, MaxNTOError};
 use crate::encode::ternarytree::{TTFlatPack, TernaryTree, TernaryTreeError};
@@ -199,6 +199,73 @@ fn core(m: &Bound<'_, PyModule>) -> PyResult<()> {
             Ok(Some(state)) => Ok(PyArray1::from_owned_array(py, state.state)),
             Err(e) => Err(PyErr::from(e)),
         }
+    }
+
+    /// Decode an ensemble of Z-basis states into fermionic occupation vectors.
+    ///
+    /// Args:
+    ///     states: 2D boolean array of shape ``(n_states, n_qubits)``.  Each row
+    ///         is a Z-basis computational-basis state.
+    ///     ipowers: 1D uint8 array of length ``2 * n_modes`` — phase exponents for
+    ///         each Majorana operator row.
+    ///     symplectic_matrix: 2D boolean array of shape
+    ///         ``(2 * n_modes, 2 * n_qubits)``.  Left half is the X-block, right
+    ///         half is the Z-block (same layout as all other functions here).
+    ///     vacuum_state: 1D boolean array of length ``n_qubits``.
+    ///
+    /// Returns:
+    ///     2D boolean array of shape ``(n_states, n_modes)``.  Row ``j`` is the
+    ///     fermionic occupation vector decoded from ``states[j]``.
+    ///
+    /// Raises:
+    ///     ValueError: if any state cannot be decoded (i.e., does not correspond
+    ///         to a valid encoded Fock state for this encoding).
+    #[pyfn(m)]
+    #[pyo3(name = "decode")]
+    fn wrap_decode<'py>(
+        py: Python<'py>,
+        states: PyReadonlyArray2<bool>,
+        ipowers: PyReadonlyArray1<u8>,
+        symplectic_matrix: PyReadonlyArray2<bool>,
+        vacuum_state: PyReadonlyArray1<bool>,
+    ) -> PyResult<Bound<'py, PyArray2<bool>>> {
+        let states = states.as_array().to_owned();
+        let n_states = states.nrows();
+        let symplectic_matrix = symplectic_matrix.as_array();
+        let n_qubits = symplectic_matrix.ncols() / 2;
+        let x_block = symplectic_matrix
+            .slice(ndarray::s![.., ..n_qubits])
+            .to_owned();
+        let z_block = symplectic_matrix
+            .slice(ndarray::s![.., n_qubits..])
+            .to_owned();
+        let ipowers = ipowers.as_array().to_owned();
+        let vacuum = ZBasisState::new(
+            Array1::from(vacuum_state.as_array().to_vec()),
+            num_complex::Complex::ONE,
+        );
+        let encoding = MajoranaEncoding::with_vacuum(
+            SymplecticMatrix::with_ipowers(x_block, z_block, ipowers),
+            vacuum,
+        )?;
+        let ensemble = ZBasisEnsemble::new(
+            states,
+            Array1::from_elem(n_states, num_complex::Complex::ONE),
+        );
+        let results = encoding.decode_zbasis_ensemble(&ensemble);
+        let n_modes = encoding.n_modes;
+        let mut occupations = numpy::ndarray::Array2::<bool>::default((n_states, n_modes));
+        for (j, result) in results.into_iter().enumerate() {
+            match result {
+                Some(fock) => occupations.row_mut(j).assign(&fock.state),
+                None => {
+                    return Err(PyValueError::new_err(format!(
+                        "state at index {j} could not be decoded"
+                    )))
+                }
+            }
+        }
+        Ok(PyArray2::from_owned_array(py, occupations))
     }
 
     /// Convert a symplectic operator representation to a Pauli string.

--- a/src/states.rs
+++ b/src/states.rs
@@ -1,6 +1,6 @@
 //! Structs representing quantum states.
 
-use ndarray::{s, Array1};
+use ndarray::{s, Array1, Array2};
 use num_complex::Complex64;
 use std::ops::Mul;
 use thiserror::Error;
@@ -225,6 +225,60 @@ mod zbasis_tests {
         reindexed_state.reindex(&[2, 0, 1]);
         assert_eq!(reindexed_state.state, zbasis_state.state);
         assert_eq!(reindexed_state.coefficient, zbasis_state.coefficient);
+    }
+}
+
+/// A collection of quantum states in the computational (Pauli Z) basis.
+///
+/// Holds `n` states as rows of a boolean matrix, paired with complex coefficients.
+/// Intended for efficient batch decoding via [`crate::encode::encoding::MajoranaEncoding::decode_zbasis_ensemble`].
+#[derive(Debug, Clone)]
+pub struct ZBasisEnsemble {
+    /// Each row is a Z-basis state (qubit occupation vector).
+    pub states: Array2<bool>,
+    /// Complex coefficient for each state.
+    pub coefficients: Array1<Complex64>,
+}
+
+impl ZBasisEnsemble {
+    /// Construct a [`ZBasisEnsemble`] from a states matrix and coefficient vector.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `states.nrows() != coefficients.len()`.
+    pub fn new(states: Array2<bool>, coefficients: Array1<Complex64>) -> Self {
+        assert_eq!(
+            states.nrows(),
+            coefficients.len(),
+            "states and coefficients must have the same length"
+        );
+        Self {
+            states,
+            coefficients,
+        }
+    }
+}
+
+impl From<Vec<ZBasisState>> for ZBasisEnsemble {
+    fn from(zbasis_states: Vec<ZBasisState>) -> Self {
+        let n = zbasis_states.len();
+        if n == 0 {
+            return Self {
+                states: Array2::default((0, 0)),
+                coefficients: Array1::default(0),
+            };
+        }
+        let n_qubits = zbasis_states[0].state.len();
+        let mut states = Array2::default((n, n_qubits));
+        let mut coefficients = Array1::zeros(n);
+        for (i, s) in zbasis_states.iter().enumerate() {
+            states.row_mut(i).assign(&s.state);
+            coefficients[i] = s.coefficient;
+        }
+        Self {
+            states,
+            coefficients,
+        }
     }
 }
 


### PR DESCRIPTION
Introduces `ZBasisEnsemble` (Array2<bool> states + Array1<Complex64>
coefficients) and `MajoranaEncoding::decode_zbasis_ensemble`, which
decodes all rows of the ensemble in one pass per mode — applying each
annihilation operator across every row in-place via Rayon before
advancing to the next mode, avoiding per-state array clones.

Adds criterion benchmarks comparing batch vs sequential decode at
ensemble sizes 10, 100 and 1000, and proptest/unit tests asserting
batch results match single-state decode for all standard encodings.

https://claude.ai/code/session_013szAhdyfQpAKcDhcKAGUKS