### PR TITLE
Support leaf Majorana indices in ternary tree flatpack 

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,7 @@
+# Pre-commit hooks
+Before committing and creating pull-requests run `uv run pre-commit run --all`
+
+# Tests
+Cargo tests must be run as `cargo test --workspace`.
+
+Python tests should be run with `uv run pytest -n auto`.

--- a/crates/ferrmion-core/src/encode/ternarytree.rs
+++ b/crates/ferrmion-core/src/encode/ternarytree.rs
@@ -296,7 +296,9 @@ impl TernaryTree {
 
         debug!("Flatpack nodes have qubit indices {:?}", &qubit_node_map);
 
-        // Leaf values are encoded as Majorana_index + max_node_index.
+        // Leaf values are encoded as Majorana_index + max_node_index + 1.
+        // The +1 ensures that even Majorana index 0 maps to a value strictly greater
+        // than max_node_index and can therefore never be confused with a node qubit index.
         // Node qubit indices may be non-contiguous (e.g. from the bonsai algorithm).
         let max_node_index = qubit_node_map.keys().copied().max().unwrap_or(0);
 
@@ -315,9 +317,9 @@ impl TernaryTree {
                         self.add_child(Parent::new(edge, parent), Child::Node(node_idx as u8))?;
                     } else if process_leaves {
                         // c is not a node — decode as a leaf.
-                        // Majorana index m = c - max_node_index.
+                        // Majorana index m = c - (max_node_index + 1).
                         // Even m → XLeaf(m/2), odd m → YLeaf((m-1)/2).
-                        let m = c.checked_sub(max_node_index)
+                        let m = c.checked_sub(max_node_index + 1)
                             .ok_or_else(|| TernaryTreeError::FlatPackError(flatpack.clone()))?;
                         let leaf = if m % 2 == 0 {
                             Child::XLeaf((m / 2) as u8)

--- a/crates/ferrmion-core/src/encode/ternarytree.rs
+++ b/crates/ferrmion-core/src/encode/ternarytree.rs
@@ -319,7 +319,8 @@ impl TernaryTree {
                         // c is not a node — decode as a leaf.
                         // Majorana index m = c - (max_node_index + 1).
                         // Even m → XLeaf(m/2), odd m → YLeaf((m-1)/2).
-                        let m = c.checked_sub(max_node_index + 1)
+                        let m = c
+                            .checked_sub(max_node_index + 1)
                             .ok_or_else(|| TernaryTreeError::FlatPackError(flatpack.clone()))?;
                         let leaf = if m % 2 == 0 {
                             Child::XLeaf((m / 2) as u8)

--- a/crates/ferrmion-core/src/encode/ternarytree.rs
+++ b/crates/ferrmion-core/src/encode/ternarytree.rs
@@ -249,11 +249,14 @@ impl TernaryTree {
     pub fn from_flatpack(flatpack: &TTFlatPack) -> Result<TernaryTree, TernaryTreeError> {
         let n_nodes = flatpack.len();
         let mut tree = TernaryTree::new(n_nodes);
-        tree.add_children_from_flatpack(flatpack)?;
+        tree.add_children_from_flatpack(flatpack, true)?;
         Ok(tree)
     }
 
     /// Builds a naive enumeration TernaryTree from a flatpack representation.
+    ///
+    /// Leaf child values in the flatpack are ignored; the naive default leaf
+    /// assignment (`XLeaf(i)` / `YLeaf(i)` for each node `i`) is applied as usual.
     ///
     /// # Examples
     ///
@@ -265,13 +268,18 @@ impl TernaryTree {
     pub fn from_flatpack_naive(flatpack: &TTFlatPack) -> Result<TernaryTree, TernaryTreeError> {
         let n_nodes = flatpack.len();
         let mut tree = TernaryTree::new_naive(n_nodes);
-        tree.add_children_from_flatpack(flatpack)?;
+        tree.add_children_from_flatpack(flatpack, false)?;
         Ok(tree)
     }
 
+    /// `process_leaves`: when `true`, child values not found in `qubit_node_map` are
+    /// decoded as leaves (`child_value - max_node_index` gives the Majorana index).
+    /// When `false` (naive mode), such values are silently ignored and the existing
+    /// default leaf assignment is left intact.
     fn add_children_from_flatpack(
         &mut self,
         flatpack: &TTFlatPack,
+        process_leaves: bool,
     ) -> Result<(), TernaryTreeError> {
         let n_nodes = self.n_nodes;
         let qubit_index_of: Vec<usize> = flatpack.iter().map(|v| v.0).collect();
@@ -288,20 +296,41 @@ impl TernaryTree {
 
         debug!("Flatpack nodes have qubit indices {:?}", &qubit_node_map);
 
-        for &(parent, children) in flatpack.iter() {
+        // Leaf values are encoded as Majorana_index + max_node_index.
+        // Node qubit indices may be non-contiguous (e.g. from the bonsai algorithm).
+        let max_node_index = qubit_node_map.keys().copied().max().unwrap_or(0);
+
+        for (qubit_index, children) in flatpack.iter() {
             let parent = *qubit_node_map
-                .get(&parent)
+                .get(qubit_index)
                 .ok_or_else(|| TernaryTreeError::FlatPackError(flatpack.clone()))?
                 as u8;
             for (child, edge) in std::iter::zip(
                 [children.0, children.1, children.2],
                 [Edge::X, Edge::Y, Edge::Z],
             ) {
-                if let Some(index) = child {
-                    let index = *qubit_node_map
-                        .get(&index)
-                        .ok_or_else(|| TernaryTreeError::FlatPackError(flatpack.clone()))?;
-                    self.add_child(Parent::new(edge, parent), Child::Node(index as u8))?
+                if let Some(c) = child {
+                    if let Some(&node_idx) = qubit_node_map.get(&c) {
+                        // c is a known node qubit index — add as a Node child.
+                        self.add_child(Parent::new(edge, parent), Child::Node(node_idx as u8))?;
+                    } else if process_leaves {
+                        // c is not a node — decode as a leaf.
+                        // Majorana index m = c - max_node_index.
+                        // Even m → XLeaf(m/2), odd m → YLeaf((m-1)/2).
+                        let m = c.checked_sub(max_node_index)
+                            .ok_or_else(|| TernaryTreeError::FlatPackError(flatpack.clone()))?;
+                        let leaf = if m % 2 == 0 {
+                            Child::XLeaf((m / 2) as u8)
+                        } else {
+                            Child::YLeaf(((m - 1) / 2) as u8)
+                        };
+                        match edge {
+                            Edge::X => self.x_child_of[parent as usize] = Some(leaf),
+                            Edge::Y => self.y_child_of[parent as usize] = Some(leaf),
+                            Edge::Z => self.z_child_of[parent as usize] = Some(leaf),
+                        }
+                    }
+                    // else: not process_leaves — unknown index silently ignored (naive mode)
                 }
             }
         }

--- a/python/ferrmion/encode/ternary_tree.py
+++ b/python/ferrmion/encode/ternary_tree.py
@@ -213,8 +213,9 @@ class TernaryTree(FermionQubitEncoding):
         Node children are represented by their qubit index (an int that also
         appears as the first element of some flatpack entry).  Leaf children
         with a known Majorana index are encoded as
-        ``majorana_index + max_node_index``, which is strictly greater than
-        every node qubit index and can therefore never be confused with a node.
+        ``majorana_index + max_node_index + 1``, which is strictly greater than
+        every node qubit index (including when the Majorana index is 0) and can
+        therefore never be confused with a node.
         Leaves without a known Majorana index are represented as ``None``.
 
         Returns:
@@ -235,7 +236,7 @@ class TernaryTree(FermionQubitEncoding):
                 else:
                     majorana_idx = node.leaf_majorana_indices.get(edge)
                     if majorana_idx is not None:
-                        children[i] = majorana_idx + max_node_index
+                        children[i] = majorana_idx + max_node_index + 1
 
             flatpack.append(
                 (
@@ -275,12 +276,12 @@ class TernaryTree(FermionQubitEncoding):
                     if child in node_qubit_indices:
                         used_qubit_indices.append(child)
                     elif child > max_node_index:
-                        pass  # leaf: Majorana index = child - max_node_index
+                        pass  # leaf: Majorana index = child - (max_node_index + 1)
                     else:
                         raise TypeError(
                             f"TTFlatpack child {child} is not a node qubit index and is "
                             f"<= max_node_index ({max_node_index}); leaf values must be "
-                            "> max_node_index (i.e. majorana_index + max_node_index)."
+                            "> max_node_index (i.e. majorana_index + max_node_index + 1)."
                         )
                 elif child is None:
                     continue
@@ -299,7 +300,7 @@ class TernaryTree(FermionQubitEncoding):
                 if isinstance(child, int) and child in node_qubit_indices:
                     setattr(node, edge, nodes[child])
                 elif isinstance(child, int) and child > max_node_index:
-                    node.leaf_majorana_indices[edge] = child - max_node_index
+                    node.leaf_majorana_indices[edge] = child - (max_node_index + 1)
         root = nodes[flatpack[0][0]]
         enumeration_scheme = {}
         mode_counter = [0]

--- a/python/ferrmion/encode/ternary_tree.py
+++ b/python/ferrmion/encode/ternary_tree.py
@@ -17,9 +17,10 @@ logger = logging.getLogger(__name__)
 
 """Instructions to build a TernaryTree.
 
-The first item in the list gives the qubit-index of the  root node,
-followed by the qubit indices of its child nodes (ordered X, Y, Z).
-If no child exists, None is used.
+Each node in the tree is represented as a tuple of (qubit_index, (x_child, y_child, z_child)).
+
+To ensure there are no clashes between qubit indices and majorana indices,
+majorana indices should be offset by max(qubit_indices) + 1.
 """
 type TTFlatpack = list[tuple[int, tuple[int | None, int | None, int | None]]]
 
@@ -157,7 +158,15 @@ class TernaryTree(FermionQubitEncoding):
     def encode_topphatt(
         self, fham: FermionHamiltonian, parallelize: bool = True
     ) -> QubitHamiltonian:
-        """Encode a Hamiltonian, using TOPP-HATT optimisation."""
+        """Encode a Hamiltonian, using TOPP-HATT optimisation.
+
+        Args:
+            fham: The FermionHamiltonian to encode.
+            parallelize: Whether to parallelize the encoding.
+
+        Returns:
+            The encoded QubitHamiltonian.
+        """
         sigs, coeffs = fham.signatures_and_coefficients
         ipow, sym, qham, vacuum = core.encode_topphatt(
             flatpack=self.flatpack(),
@@ -208,7 +217,7 @@ class TernaryTree(FermionQubitEncoding):
         )
 
     def flatpack(self) -> TTFlatpack:
-        """Create a TTFlatpack from the tree, which can be passed to rust functions.
+        """Create a TTFlatpack from the tree, which can be saved or passed to rust functions.
 
         Node children are represented by their qubit index (an int that also
         appears as the first element of some flatpack entry).  Leaf children
@@ -220,8 +229,14 @@ class TernaryTree(FermionQubitEncoding):
 
         Returns:
             list[tuple[int, tuple[int | None, int | None, int | None]]]
+
+        Example:
+            >>> TernaryTree(4).JW().flatpack()
+            >>> [(0, (4, 5,1)), (1, (6,7,2)), (2, (8,9,3)), (3, (10,11,4))]
         """
-        max_node_index: int = max(qubit for _, qubit in self.enumeration_scheme.values())
+        max_node_index: int = max(
+            qubit for _, qubit in self.enumeration_scheme.values()
+        )
         flatpack: TTFlatpack = []
 
         to_flatten: list[TTNode] = [self.root_node]
@@ -291,8 +306,7 @@ class TernaryTree(FermionQubitEncoding):
                     )
 
         ipow, sym, vacuum = core.flatpack_symplectic_matrix(flatpack, None)
-        max_id = max_node_index
-        nodes = [TTNode() for _ in range(max_id + 1)]
+        nodes = [TTNode() for _ in range(max_node_index + 1)]
         for qubit_index, children in flatpack:
             node = nodes[qubit_index]
             node.qubit_index = qubit_index
@@ -301,6 +315,7 @@ class TernaryTree(FermionQubitEncoding):
                     setattr(node, edge, nodes[child])
                 elif isinstance(child, int) and child > max_node_index:
                     node.leaf_majorana_indices[edge] = child - (max_node_index + 1)
+
         root = nodes[flatpack[0][0]]
         enumeration_scheme = {}
         mode_counter = [0]

--- a/python/ferrmion/encode/ternary_tree.py
+++ b/python/ferrmion/encode/ternary_tree.py
@@ -210,24 +210,32 @@ class TernaryTree(FermionQubitEncoding):
     def flatpack(self) -> TTFlatpack:
         """Create a TTFlatpack from the tree, which can be passed to rust functions.
 
+        Node children are represented by their qubit index (an int that also
+        appears as the first element of some flatpack entry).  Leaf children
+        with a known Majorana index are encoded as
+        ``majorana_index + max_node_index``, which is strictly greater than
+        every node qubit index and can therefore never be confused with a node.
+        Leaves without a known Majorana index are represented as ``None``.
+
         Returns:
-            list[tuple[int, tuple[int,int,int]]]
+            list[tuple[int, tuple[int | None, int | None, int | None]]]
         """
+        max_node_index: int = max(qubit for _, qubit in self.enumeration_scheme.values())
         flatpack: TTFlatpack = []
 
         to_flatten: list[TTNode] = [self.root_node]
         while len(to_flatten) > 0:
             node: TTNode = to_flatten.pop(0)
             children: list[int | None] = [None, None, None]
-            if isinstance(node.x, TTNode):
-                to_flatten.append(node.x)
-                children[0] = self.enumeration_scheme[node.x.root_path][1]
-            if isinstance(node.y, TTNode):
-                to_flatten.append(node.y)
-                children[1] = self.enumeration_scheme[node.y.root_path][1]
-            if isinstance(node.z, TTNode):
-                to_flatten.append(node.z)
-                children[2] = self.enumeration_scheme[node.z.root_path][1]
+            for i, edge in enumerate(["x", "y", "z"]):
+                child_node = getattr(node, edge)
+                if isinstance(child_node, TTNode):
+                    to_flatten.append(child_node)
+                    children[i] = self.enumeration_scheme[child_node.root_path][1]
+                else:
+                    majorana_idx = node.leaf_majorana_indices.get(edge)
+                    if majorana_idx is not None:
+                        children[i] = majorana_idx + max_node_index
 
             flatpack.append(
                 (
@@ -253,6 +261,8 @@ class TernaryTree(FermionQubitEncoding):
         """
         if not flatpack:
             raise ValueError("Flatpack cannot be empty")
+        node_qubit_indices: set[int] = {item[0] for item in flatpack}
+        max_node_index: int = max(node_qubit_indices)
         used_qubit_indices = [flatpack[0][0]]
         for item in flatpack:
             if item[0] not in used_qubit_indices:
@@ -262,23 +272,34 @@ class TernaryTree(FermionQubitEncoding):
                 raise TypeError("TTFlatpack nodes must have three optional children.")
             for child in children:
                 if isinstance(child, int):
-                    used_qubit_indices.append(child)
+                    if child in node_qubit_indices:
+                        used_qubit_indices.append(child)
+                    elif child > max_node_index:
+                        pass  # leaf: Majorana index = child - max_node_index
+                    else:
+                        raise TypeError(
+                            f"TTFlatpack child {child} is not a node qubit index and is "
+                            f"<= max_node_index ({max_node_index}); leaf values must be "
+                            "> max_node_index (i.e. majorana_index + max_node_index)."
+                        )
                 elif child is None:
                     continue
                 else:
                     raise TypeError(
-                        "TTFlatpack contains child node which is not int | None."
+                        "TTFlatpack contains child which is not int | None."
                     )
 
         ipow, sym, vacuum = core.flatpack_symplectic_matrix(flatpack, None)
-        max_id = max(item[0] for item in flatpack)
+        max_id = max_node_index
         nodes = [TTNode() for _ in range(max_id + 1)]
         for qubit_index, children in flatpack:
             node = nodes[qubit_index]
             node.qubit_index = qubit_index
-            node.x = nodes[children[0]] if children[0] is not None else None
-            node.y = nodes[children[1]] if children[1] is not None else None
-            node.z = nodes[children[2]] if children[2] is not None else None
+            for edge, child in zip(["x", "y", "z"], children):
+                if isinstance(child, int) and child in node_qubit_indices:
+                    setattr(node, edge, nodes[child])
+                elif isinstance(child, int) and child > max_node_index:
+                    node.leaf_majorana_indices[edge] = child - max_node_index
         root = nodes[flatpack[0][0]]
         enumeration_scheme = {}
         mode_counter = [0]


### PR DESCRIPTION
Flatpacks currently only contain information about nodes, which makes it difficult to store information about optimised enumerations, and to pass optimised trees across the python/rust boundary. (For instance, huffman trees would be assinged a new naive enumeration).

Majorana indices in the range 0..2*n_modes can be added to the flatplack if they use an offest which makes sure they don't clash with the qubit indices of nodes.

The implementation here is pretty straightforward, but it does mean it's possible to create flatpacks that aren't valid (repeated indices, cyclic graphs). If that becomes an issue in the future then something more involved can be done.