### PR TITLE
Constants

### DIFF
--- a/crates/ferrmion-core/src/encode/majorana.rs
+++ b/crates/ferrmion-core/src/encode/majorana.rs
@@ -9,6 +9,7 @@ use crate::operators::{
 };
 use crate::spaces::{Fermion, Qubit};
 use crate::states::{FockState, ZBasisEnsemble, ZBasisState};
+use crate::utils::COEFFICIENT_TOLERANCE;
 use crate::utils::{self, icount_to_sign};
 use log::{debug, error};
 use ndarray::{Array1, Array2, Axis, Zip};
@@ -531,7 +532,11 @@ impl Encode<&MajoranaSparse, QubitHamiltonian> for MajoranaEncoding {
                     .collect::<String>(),
             )
             .or_insert(c64(0., 0.)) += input.constant;
-        QubitHamiltonian(qham.into_iter().filter(|(_, v)| v.norm() > 1e-16).collect())
+        QubitHamiltonian(
+            qham.into_iter()
+                .filter(|(_, v)| v.norm() > COEFFICIENT_TOLERANCE)
+                .collect(),
+        )
     }
 }
 
@@ -583,7 +588,7 @@ impl MajoranaEncoding {
 
             let ann_coeff = left.coefficient + Complex64::new(0., 1.) * right.coefficient;
 
-            if ann_coeff.norm() > 1e-10 {
+            if ann_coeff.norm() > COEFFICIENT_TOLERANCE {
                 occupation[i] = true;
                 current = ZBasisState::new(left.state, ann_coeff);
             }
@@ -671,7 +676,7 @@ impl MajoranaEncoding {
             // Determine which states have mode i occupied.
             let occupied: Vec<bool> = ann_coeffs
                 .iter()
-                .map(|c: &Complex64| c.norm() > 1e-10)
+                .map(|c: &Complex64| c.norm() > COEFFICIENT_TOLERANCE)
                 .collect();
 
             // Update occupations and accumulated coefficients.
@@ -764,7 +769,6 @@ impl TryEncode<FockState, ZBasisState> for MajoranaEncoding {
 #[cfg(test)]
 mod owned_tests {
     use super::*;
-
     use crate::encode::ternarytree::TernaryTree;
     use crate::operators::LadderOperator;
     use crate::states::{State, ZBasisEnsemble};
@@ -1338,7 +1342,7 @@ mod batch_tests {
                 let qham = enumerated.encode(&ms);
                 prop_assert_eq!(qham.pauli_weight() as f64, plain_weight);
                 prop_assert!(
-                    (qham.coeff_pauli_weight() - coeff_weight).abs() < 1e-10,
+                    (qham.coeff_pauli_weight() - coeff_weight).abs() < crate::utils::WEIGHT_TOLERANCE,
                     "expected coeff weight {}, got {}", qham.coeff_pauli_weight(), coeff_weight
                 );
             }

--- a/crates/ferrmion-core/src/hamiltonians.rs
+++ b/crates/ferrmion-core/src/hamiltonians.rs
@@ -3,6 +3,7 @@ use crate::operators::{
     PauliWeight, SymplecticMatrix, SymplecticOperatorView,
 };
 use crate::spaces::{Fermion, Qubit};
+use crate::utils::{icount_to_sign, pauli_to_symplectic, COEFFICIENT_TOLERANCE};
 use ahash::RandomState;
 use ndarray::{Array1, Array2, ArrayD, ArrayViewD, Axis, Zip};
 use num_complex::Complex64;
@@ -223,7 +224,7 @@ impl SymplecticHamiltonian {
 
         for (i, (pauli_str, coeff)) in qham.iter().enumerate() {
             // returns ([x_block | z_block], n_Y % 4)
-            let (symplectic, ipower) = crate::utils::pauli_to_symplectic(pauli_str.clone(), 0);
+            let (symplectic, ipower) = pauli_to_symplectic(pauli_str.clone(), 0);
             x_data.extend(symplectic.iter().take(n_qubits).copied());
             z_data.extend(symplectic.iter().skip(n_qubits).copied());
             ipowers[i] = ipower as u8;
@@ -243,15 +244,15 @@ impl SymplecticHamiltonian {
     /// `view_row(i).to_pauli_string()` accumulates Y-convention corrections and
     /// sign changes from H gates into `total_ipower`. For a Hermitian molecular
     /// Hamiltonian this is always 0 or 2 (±1), keeping all coefficients real.
-    /// Terms mapping to the same Pauli string are summed; results below 1e-12
+    /// Terms mapping to the same Pauli string are summed; results below tolerance
     /// are dropped.
     pub fn to_qubit_hamiltonian(&self) -> QubitHamiltonian {
         let mut result = QubitHamiltonian::default();
         for i in 0..self.coefficients.len() {
             let (pauli_str, total_ipower) = self.operators.view_row(i).to_pauli_string();
-            let phase = crate::utils::icount_to_sign(total_ipower as usize);
+            let phase = icount_to_sign(total_ipower as usize);
             let actual_coeff = Complex64::new(self.coefficients[i], 0.) * phase;
-            if actual_coeff.norm() > 1e-12 {
+            if actual_coeff.norm() > COEFFICIENT_TOLERANCE {
                 result
                     .0
                     .entry(pauli_str)

--- a/crates/ferrmion-core/src/operators/fermion.rs
+++ b/crates/ferrmion-core/src/operators/fermion.rs
@@ -1,6 +1,7 @@
 //! Fermionic Operators
 use crate::operators::ladder::LadderOperator;
 use crate::spaces::Fermion;
+use crate::utils::COEFFICIENT_TOLERANCE;
 use itertools::Itertools;
 use log::debug;
 use ndarray::{arr0, s, Dimension};
@@ -556,7 +557,11 @@ impl From<MajoranaHashMap> for MajoranaSparse {
     fn from(mbt: MajoranaHashMap) -> MajoranaSparse {
         let mut sparse_constant: num_complex::Complex<f64> = c64(0., 0.);
         let mut pairs: Vec<(ArrayVec<[u16; MAX_MAJORANAS]>, Complex64)> = Vec::new();
-        for (k, v) in mbt.operators.into_iter().filter(|(_, v)| v.abs() >= 1e-16) {
+        for (k, v) in mbt
+            .operators
+            .into_iter()
+            .filter(|(_, v)| v.abs() >= COEFFICIENT_TOLERANCE)
+        {
             if k.is_empty() {
                 sparse_constant += v;
             } else {

--- a/crates/ferrmion-core/src/utils.rs
+++ b/crates/ferrmion-core/src/utils.rs
@@ -3,6 +3,10 @@ use ndarray::{concatenate, Axis, Zip};
 use ndarray::{Array1, ArrayView1};
 use num_complex::Complex64;
 
+pub const COEFFICIENT_TOLERANCE: f64 = 1e-16;
+pub const ENERGY_TOLERANCE: f64 = 1e-10;
+pub const WEIGHT_TOLERANCE: f64 = 1e-6;
+
 /// Converts an imaginary count to a complex sign.
 ///
 /// # Examples

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -9,6 +9,8 @@ from openfermion import InteractionOperator, jordan_wigner, get_sparse_operator,
 from scipy.sparse.linalg import eigsh
 from ferrmion.hamiltonians import FermionHamiltonian
 
+ENERGY_TOLERANCE = 1e-10
+WEIGHT_TOLERANCE = 1e-6
 
 @fixture(scope="module")
 def water_data():

--- a/python/tests/test_optimize/test_clifford_heuristic.py
+++ b/python/tests/test_optimize/test_clifford_heuristic.py
@@ -1,4 +1,5 @@
 """Tests for the Clifford heuristic encoding optimisation."""
+from qiskit.primitives.containers.bit_array import _WEIGHT_LOOKUP
 
 import numpy as np
 import pytest
@@ -7,6 +8,7 @@ from ferrmion.encode.ternary_tree import JordanWigner, BravyiKitaev, ParityEncod
 from ferrmion.optimize.cost_functions import coefficient_pauli_weight, pauli_weight
 from openfermion import QubitOperator, get_sparse_operator
 from scipy.sparse.linalg import eigsh
+from ..conftest import ENERGY_TOLERANCE, WEIGHT_TOLERANCE
 
 
 def _qham_to_ofop(qham: dict) -> QubitOperator:
@@ -38,7 +40,7 @@ def test_clifford_heuristic_does_not_increase_pauli_weight(encoding_cls, h2_mol_
     )
     opt_weight = pauli_weight(opt_qham)[0]
 
-    assert opt_weight <= baseline_weight + 1e-6
+    assert opt_weight <= baseline_weight + WEIGHT_TOLERANCE
 
 
 @pytest.mark.parametrize("encoding_cls", [JordanWigner, ParityEncoding, BravyiKitaev, JKMN])
@@ -59,7 +61,7 @@ def test_clifford_heuristic_does_not_increase_coeff_pauli_weight(encoding_cls, w
     )
     opt_weight = coefficient_pauli_weight(opt_qham)[0]
 
-    assert opt_weight <= baseline_weight + 1e-6
+    assert opt_weight <= baseline_weight + WEIGHT_TOLERANCE
 
 
 def test_clifford_heuristic_seed_is_reproducible(h2_mol_data_sets):
@@ -101,7 +103,7 @@ def test_clifford_heuristic_preserves_constant_energy(h2_mol_data_sets):
     identity_key = "I" * qham_const.n_qubits
     base_identity = qham_base.get(identity_key, complex(0)).real
     assert identity_key in qham_const
-    assert abs(qham_const[identity_key].real - base_identity - constant_energy) < 1e-10
+    assert abs(qham_const[identity_key].real - base_identity - constant_energy) < ENERGY_TOLERANCE
 
 
 def test_clifford_heuristic_preserves_eigenvalues(h2_mol_data_sets):

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -42,7 +42,7 @@ pub(crate) fn simplified_majorana_terms(
         }
         *merged.entry(simplified).or_insert(Complex64::new(0., 0.)) += val;
     }
-    merged.retain(|_, v| v.norm() > 1e-16);
+    merged.retain(|_, v| v.norm() > utils::COEFFICIENT_TOLERANCE);
     merged
 }
 


### PR DESCRIPTION
Replaces magic numbers which were used as tolerances in various parts of the codebase with consts, kept in `utils`. 