### PR TITLE
Fix 32-bit release build: use u64 for MajoranaHashMap shard hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- 32-bit release wheels (`armv7`, `i686`) failed to compile because
+  `MajoranaHashMap::merge_into`'s stable shard hash used `usize` with 64-bit
+  FNV-1a constants, which overflow `usize` on 32-bit targets. The hash is now
+  computed in `u64`, so the constants are valid on every target width (hash
+  values are unchanged on 64-bit hosts).
+
 ## [0.10.0] - 2026-07-01
 
 ### Added

--- a/crates/ferrmion-core/src/operators/fermion.rs
+++ b/crates/ferrmion-core/src/operators/fermion.rs
@@ -463,12 +463,13 @@ impl MajoranaHashMap {
                     *self.operators.entry(*key).or_insert(Complex64::ZERO) += value;
                 } else {
                     // Stable (run-independent) hash of a Majorana key used to assign it to a merge
-                    // shard. FNV-1a over the `u16` indices — cheap and well-spread.
-                    let mut hash: usize = 0xcbf2_9ce4_8422_2325;
+                    // shard. FNV-1a over the `u16` indices — cheap and well-spread. Uses `u64`
+                    // (not `usize`) so the 64-bit FNV constants are valid on 32-bit targets too.
+                    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
                     for &index in key.iter() {
-                        hash = (hash ^ index as usize).wrapping_mul(0x0100_0000_01b3);
+                        hash = (hash ^ index as u64).wrapping_mul(0x0100_0000_01b3);
                     }
-                    if hash % n_shards == shard {
+                    if (hash % n_shards as u64) as usize == shard {
                         *self.operators.entry(*key).or_insert(Complex64::ZERO) += value;
                     }
                 }


### PR DESCRIPTION
MajoranaHashMap::merge_into computed a stable FNV-1a shard hash of each
Majorana key in a `usize` accumulator using the 64-bit FNV-1a offset
basis and prime. On 32-bit targets (armv7, i686) those literals exceed
usize::MAX, so #[deny(overflowing_literals)] failed the release wheel
cross-compilation for every 32-bit platform.

Compute the hash in u64 (constants valid on all target widths) and cast
the reduced remainder back to usize for the shard comparison. On 64-bit
hosts usize == u64, so the hash values and all sharding/merge behaviour
are unchanged.

Verified with `cargo check -p ferrmion-core --target i686-unknown-linux-gnu`
(the overflowing_literals lint fires during type-check): errors before,
clean after.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MBkLzFBVJTwR7UwaPn53B9