### PR TITLE
Msparse everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-08-10
+
+### Added
+
+- `MajoranaEncoding.encode_annealed`, `.anneal_enumeration`,
+  `.batch_pauli_weights`, and the `hatt` / `encode_topphatt` module functions
+  now accept a `MajoranaSparse` as well as a `FermionHamiltonian`, matching
+  `MajoranaEncoding.encode`. `TernaryTree.encode_annealed`, `.topphatt`,
+  `.encode`, and `hamiltonian_adaptive_ternary_tree` accept both types for the
+  same reason.
+- `MajoranaSparse.n_modes` exposes the mode count of the `FermionHamiltonian`
+  it was converted from.
+- `MajoranaSparse.to_dict()` converts to a dictionary mapping Majorana index
+  tuples to coefficients.
+
+### Changed
+
+- The `fham` parameter on `MajoranaEncoding.encode_annealed`,
+  `.anneal_enumeration`, `.batch_pauli_weights`, `hatt`, and `encode_topphatt`
+  is renamed `operator`, matching `encode`. Positional calls are unaffected;
+  callers passing it by keyword need updating.
+
+### Fixed
+
+- `TernaryTree.encode` previously raised `TypeError` when passed a
+  `MajoranaSparse` despite its type hint claiming support; it now works as
+  documented.
+
+### Removed
+
+- `FermionHamiltonian.to_sparse_majorana()` is removed. Use
+  `FermionHamiltonian.to_majorana_sparse().to_dict()` instead.
+
 ## [0.13.0] - 2026-08-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrmion"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "criterion",
  "ferrmion-core",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "ferrmion-core"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "ahash",
  "argmin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "ferrmion"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/ferrmion-core/Cargo.toml
+++ b/crates/ferrmion-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrmion-core"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 description = "Fast, easy and optimised fermion-qubit encodings."
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,7 @@
 project = 'ferrmion'
 copyright = '2025, Michael Williams de la Bastida'
 author = 'Michael Williams de la Bastida'
-version = "0.13.0"
+version = "0.13.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
     "deap>=1.4.3",
     "rustworkx>=0.16.0",

--- a/python/ferrmion/core.pyi
+++ b/python/ferrmion/core.pyi
@@ -66,7 +66,6 @@ class FermionHamiltonian:
         self, coefficients: npt.NDArray[np.float64]
     ) -> "FermionHamiltonian": ...
     def add_constant(self, constant_energy: float) -> "FermionHamiltonian": ...
-    def to_sparse_majorana(self) -> dict[tuple[int, ...], complex]: ...
     def to_majorana_sparse(self) -> "MajoranaSparse": ...
 
 class MajoranaSparse:
@@ -78,6 +77,9 @@ class MajoranaSparse:
     def coefficients(self) -> npt.NDArray[np.complex128]: ...
     @property
     def constant(self) -> float: ...
+    @property
+    def n_modes(self) -> int: ...
+    def to_dict(self) -> dict[tuple[int, ...], complex]: ...
 
 class MajoranaEncoding:
     """A fermion-to-qubit encoding defined by its Majorana operators."""
@@ -124,7 +126,7 @@ class MajoranaEncoding:
     ) -> QubitHamiltonian: ...
     def encode_annealed(
         self,
-        fham: FermionHamiltonian,
+        operator: FermionHamiltonian | MajoranaSparse,
         temperature: float | None = None,
         initial_guess: list[int] | None = None,
         coefficient_weighted: bool = True,
@@ -132,7 +134,7 @@ class MajoranaEncoding:
     ) -> QubitHamiltonian: ...
     def anneal_enumeration(
         self,
-        fham: FermionHamiltonian,
+        operator: FermionHamiltonian | MajoranaSparse,
         temperature: float | None = None,
         initial_guess: list[int] | None = None,
         coefficient_weighted: bool = False,
@@ -172,7 +174,7 @@ class MajoranaEncoding:
     ) -> tuple[str, complex]: ...
     def batch_pauli_weights(
         self,
-        fham: FermionHamiltonian,
+        operator: FermionHamiltonian | MajoranaSparse,
         permutations: npt.NDArray[np.uint],
     ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]: ...
     def apply_mode_enumeration(self, mode_op_map: list[int]) -> "MajoranaEncoding": ...
@@ -191,7 +193,7 @@ def symplectic_to_sparse(
     ipower: int,
 ) -> tuple[str, npt.NDArray[np.uintp], complex]: ...
 def hatt(
-    fham: FermionHamiltonian,
+    operator: FermionHamiltonian | MajoranaSparse,
     n_modes: int | None = None,
 ) -> tuple[TTFlatpack, int]: ...
 def topphatt(
@@ -206,7 +208,7 @@ def topphatt(
 def encode_topphatt(
     flatpack: TTFlatpack,
     n_qubits: int,
-    fham: FermionHamiltonian,
+    operator: FermionHamiltonian | MajoranaSparse,
     parallelize: bool = True,
     heuristic: str = "min_weight",
     seed: int | None = None,

--- a/python/ferrmion/encode/ternary_tree.py
+++ b/python/ferrmion/encode/ternary_tree.py
@@ -185,7 +185,7 @@ class TernaryTree:
 
     def encode_annealed(
         self,
-        fham: FermionHamiltonian,
+        operator: FermionHamiltonian | MajoranaSparse,
         temperature: int | None = None,
         initial_guess: list[int] | None = None,
         coefficient_weighted: bool = True,
@@ -194,7 +194,9 @@ class TernaryTree:
         """Encode a Hamiltonian, optimising mode enumeration via simulated annealing.
 
         Args:
-            fham (FermionHamiltonian): The fermionic Hamiltonian to encode.
+            operator (FermionHamiltonian | MajoranaSparse): The operator to encode.
+                A ``FermionHamiltonian`` is converted to its Majorana representation
+                first; passing a ``MajoranaSparse`` directly skips that conversion.
             temperature (int | None): Initial annealing temperature. Defaults to ``n_modes // 2``.
             initial_guess (list[int] | None): Starting permutation. Defaults to identity.
             coefficient_weighted (bool): If True, minimise coefficient-weighted Pauli weight.
@@ -205,7 +207,7 @@ class TernaryTree:
             QubitHamiltonian: The encoded qubit Hamiltonian.
         """
         qham = self._encoding.encode_annealed(
-            fham,
+            operator,
             temperature=temperature,
             initial_guess=initial_guess,
             coefficient_weighted=coefficient_weighted,
@@ -215,7 +217,7 @@ class TernaryTree:
 
     def topphatt(
         self,
-        fham: FermionHamiltonian,
+        operator: FermionHamiltonian | MajoranaSparse,
         parallelize: bool = True,
         heuristic: str = "min_weight",
         seed: int | None = None,
@@ -224,7 +226,10 @@ class TernaryTree:
         """Encode a Hamiltonian, using TOPP-HATT optimisation.
 
         Args:
-            fham: The FermionHamiltonian to encode.
+            operator: The operator to encode, either a ``FermionHamiltonian`` or a
+                ``MajoranaSparse``. A ``FermionHamiltonian`` is converted to its
+                Majorana representation first; passing a ``MajoranaSparse``
+                directly skips that conversion.
             parallelize: Whether to parallelize the encoding.
             heuristic: Node-selection strategy. One of ``"min_weight"``
                 (evaluate every active node and keep the lowest Pauli weight),
@@ -243,10 +248,15 @@ class TernaryTree:
         Returns:
             QubitHamiltonian: The encoded qubit Hamiltonian.
         """
+        hamiltonian = (
+            operator
+            if isinstance(operator, MajoranaSparse)
+            else operator.to_majorana_sparse()
+        )
         return core.topphatt(
             flatpack=self.flatpack(),
             n_qubits=self.n_qubits,
-            hamiltonian=fham.to_majorana_sparse(),
+            hamiltonian=hamiltonian,
             parallelize=parallelize,
             heuristic=heuristic,
             seed=seed,
@@ -255,7 +265,7 @@ class TernaryTree:
 
     def encode(
         self,
-        fham: FermionHamiltonian,
+        operator: FermionHamiltonian | MajoranaSparse,
         parallelize: bool = True,
         heuristic: str = "min_weight",
         seed: int | None = None,
@@ -264,7 +274,10 @@ class TernaryTree:
         """Encode a Hamiltonian, using TOPP-HATT optimisation.
 
         Args:
-            fham: The FermionHamiltonian to encode.
+            operator: The operator to encode, either a ``FermionHamiltonian`` or a
+                ``MajoranaSparse``. A ``FermionHamiltonian`` is converted to its
+                Majorana representation first; passing a ``MajoranaSparse``
+                directly skips that conversion.
             parallelize: Whether to parallelize the encoding.
             heuristic: Node-selection strategy. One of ``"min_weight"``
                 (evaluate every active node and keep the lowest Pauli weight),
@@ -286,7 +299,7 @@ class TernaryTree:
         qham, enc = core.encode_topphatt(
             flatpack=self.flatpack(),
             n_qubits=self.n_qubits,
-            fham=fham,
+            operator=operator,
             parallelize=parallelize,
             heuristic=heuristic,
             seed=seed,

--- a/python/ferrmion/optimize/hatt.py
+++ b/python/ferrmion/optimize/hatt.py
@@ -2,7 +2,7 @@
 
 The greedy tree construction runs in native Rust (`ferrmion.core.hatt`);
 this module exposes a thin Python wrapper that takes a `FermionHamiltonian`
-and returns a fully-populated `TernaryTree`.
+or `MajoranaSparse` and returns a fully-populated `TernaryTree`.
 """
 
 from typing import TYPE_CHECKING
@@ -11,11 +11,12 @@ from ferrmion.encode import TernaryTree
 from ferrmion.encode.ternary_tree_node import node_sorter
 
 if TYPE_CHECKING:
+    from ferrmion.core import MajoranaSparse
     from ferrmion.hamiltonians import FermionHamiltonian
 
 
 def hamiltonian_adaptive_ternary_tree(
-    fham: "FermionHamiltonian", n_modes: int
+    fham: "FermionHamiltonian | MajoranaSparse", n_modes: int
 ) -> TernaryTree:
     """Construct an adaptive ternary tree from a fermionic Hamiltonian.
 
@@ -24,8 +25,10 @@ def hamiltonian_adaptive_ternary_tree(
     (:func:`ferrmion.core.hatt`).
 
     Args:
-        fham (FermionHamiltonian): The Hamiltonian whose terms drive the
-            greedy Pauli-weight minimisation.
+        fham (FermionHamiltonian | MajoranaSparse): The operator whose terms
+            drive the greedy Pauli-weight minimisation. A
+            ``FermionHamiltonian`` is converted to its Majorana representation
+            first; passing a ``MajoranaSparse`` directly skips that conversion.
         n_modes (int): Number of fermionic modes in the system.
 
     Returns:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -72,7 +72,7 @@ def water_fham(water_data) -> FermionHamiltonian:
 def water_sparse_majorana(water_data) -> dict:
     return FermionHamiltonian(
         terms={"+-": water_data["ones"], "++--": water_data["twos"]}
-    ).to_sparse_majorana()
+    ).to_majorana_sparse().to_dict()
 
 def diagonalise_pauli_hamiltonian(qham, neigvals:int):
     ofop = QubitOperator()

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -36,7 +36,7 @@ def test_fermionic_to_sparse_majorana() -> None:
     ones[0, 0] = 1
     twos[1, 2, 1, 2] = 2
 
-    majorana_ham = FermionHamiltonian(terms={"+-": ones, "++--": twos}).to_sparse_majorana()
+    majorana_ham = FermionHamiltonian(terms={"+-": ones, "++--": twos}).to_majorana_sparse().to_dict()
     assert majorana_ham == {
         (0, 1): np.complex128(0.5j),
         (4, 5): np.complex128(-0.5j),

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -31,7 +31,7 @@ pub struct PyMajoranaEncoding(pub MajoranaEncoding);
 /// method, so the two accepted types are dispatched at runtime by trying each
 /// variant's extraction in turn.
 #[derive(FromPyObject)]
-enum EncodeInput<'py> {
+pub(crate) enum EncodeInput<'py> {
     #[pyo3(annotation = "FermionHamiltonian")]
     Fermion(PyRef<'py, PyFermionHamiltonian>),
     #[pyo3(annotation = "MajoranaSparse")]
@@ -136,30 +136,17 @@ impl PyMajoranaEncoding {
         Ok(qham)
     }
 
-    /// Check that every Majorana index in `hamiltonian` addresses a row of this
-    /// encoding's symplectic matrix.
-    ///
-    /// [`MajoranaSparse`] carries no mode count of its own, and the core encode
-    /// indexes `operators` unguarded, so an out-of-range index would panic inside
-    /// a rayon worker rather than raise. Terms are ordered lexicographically
-    /// rather than by magnitude, so the whole index set has to be scanned; the
-    /// cost is negligible beside the symplectic multiplies it guards.
-    fn check_majorana_indices(&self, hamiltonian: &MajoranaSparse) -> Result<(), CoreError> {
-        let n_operators = 2 * self.0.n_modes;
-        match hamiltonian
-            .indices
-            .iter()
-            .flat_map(|term| term.iter())
-            .copied()
-            .max()
-        {
-            Some(max_index) if max_index as usize >= n_operators => Err(CoreError::Value(format!(
-                "MajoranaSparse has Majorana index {max_index} but encoding has {} modes \
-                 ({n_operators} Majorana operators).",
+    /// Check that a `PyMajoranaSparse`'s mode count matches this encoding's,
+    /// unless it is `0` (unspecified). Mirrors the equivalent check performed
+    /// against `FermionHamiltonian::n_modes()`.
+    fn check_majorana_n_modes(&self, msparse_n_modes: usize) -> Result<(), CoreError> {
+        if msparse_n_modes != 0 && msparse_n_modes != self.0.n_modes {
+            return Err(CoreError::Value(format!(
+                "MajoranaSparse has {msparse_n_modes} modes but encoding has {} modes.",
                 self.0.n_modes
-            ))),
-            _ => Ok(()),
+            )));
         }
+        Ok(())
     }
 }
 
@@ -381,8 +368,8 @@ impl PyMajoranaEncoding {
                 py.allow_threads(|| self.0.encode(&hamiltonian))
             }
             EncodeInput::Majorana(msparse) => {
-                let hamiltonian: &MajoranaSparse = &msparse.0;
-                self.check_majorana_indices(hamiltonian)?;
+                self.check_majorana_n_modes(msparse.n_modes)?;
+                let hamiltonian: &MajoranaSparse = &msparse.inner;
                 py.allow_threads(|| self.0.encode(hamiltonian))
             }
         };
@@ -392,7 +379,10 @@ impl PyMajoranaEncoding {
     /// Encode a Hamiltonian, optimising mode enumeration via simulated annealing.
     ///
     /// Args:
-    ///     fham: The fermionic Hamiltonian to encode.
+    ///     operator: The operator to encode, either a ``FermionHamiltonian`` or a
+    ///         ``MajoranaSparse``. A ``FermionHamiltonian`` is converted to its
+    ///         Majorana representation first; passing a ``MajoranaSparse``
+    ///         directly skips that conversion.
     ///     temperature: Initial annealing temperature. Defaults to ``n_modes // 2``.
     ///     `initial_guess`: Starting permutation. Defaults to identity.
     ///     `coefficient_weighted`: If ``True``, minimise coefficient-weighted Pauli weight.
@@ -401,18 +391,21 @@ impl PyMajoranaEncoding {
     /// Returns:
     ///     Tuple of ``(QubitHamiltonian, MajoranaEncoding)`` — the encoded
     ///     Hamiltonian and the encoding with the optimised mode enumeration.
-    #[pyo3(signature = (fham, temperature = None, initial_guess = None, coefficient_weighted = true, seed = None))]
+    #[pyo3(signature = (operator, temperature = None, initial_guess = None, coefficient_weighted = true, seed = None))]
     fn encode_annealed(
         &mut self,
         py: Python<'_>,
-        fham: PyRef<'_, PyFermionHamiltonian>,
+        operator: EncodeInput<'_>,
         temperature: Option<f64>,
         initial_guess: Option<Vec<usize>>,
         coefficient_weighted: bool,
         seed: Option<usize>,
     ) -> Result<PyQubitHamiltonian, CoreError> {
-        let hamiltonian = fham.inner.to_majorana_sparse();
-        let temperature = temperature.unwrap_or((fham.inner.n_modes() / 2) as f64);
+        let (hamiltonian, operator_n_modes) = match operator {
+            EncodeInput::Fermion(fham) => (fham.inner.to_majorana_sparse(), fham.inner.n_modes()),
+            EncodeInput::Majorana(msparse) => (msparse.inner.clone(), msparse.n_modes),
+        };
+        let temperature = temperature.unwrap_or((operator_n_modes / 2) as f64);
         let initial_guess =
             Array1::from(initial_guess.unwrap_or_else(|| (0..self.0.n_modes).collect()));
         let params = AnnealingParameters::new(temperature, 1000, seed.unwrap_or(1017));
@@ -440,7 +433,10 @@ impl PyMajoranaEncoding {
     /// Optimise the mode enumeration via simulated annealing without encoding.
     ///
     /// Args:
-    ///     fham: The fermionic Hamiltonian whose Pauli weight drives the search.
+    ///     operator: The operator whose Pauli weight drives the search, either a
+    ///         ``FermionHamiltonian`` or a ``MajoranaSparse``. A
+    ///         ``FermionHamiltonian`` is converted to its Majorana representation
+    ///         first; passing a ``MajoranaSparse`` directly skips that conversion.
     ///     temperature: Initial annealing temperature. Defaults to ``n_modes``.
     ///     `initial_guess`: Starting permutation. Defaults to identity.
     ///     `coefficient_weighted`: If ``True``, minimise coefficient-weighted Pauli weight.
@@ -448,19 +444,22 @@ impl PyMajoranaEncoding {
     ///
     /// Returns:
     ///     Tuple of ``(best_cost, MajoranaEncoding)``.
-    #[pyo3(signature = (fham, temperature = None, initial_guess = None, coefficient_weighted = false, seed = None))]
+    #[pyo3(signature = (operator, temperature = None, initial_guess = None, coefficient_weighted = false, seed = None))]
     fn anneal_enumeration(
         &mut self,
         py: Python<'_>,
-        fham: PyRef<'_, PyFermionHamiltonian>,
+        operator: EncodeInput<'_>,
         temperature: Option<f64>,
         initial_guess: Option<Vec<usize>>,
         coefficient_weighted: bool,
         seed: Option<usize>,
     ) -> Result<f64, CoreError> {
-        let mut hamiltonian = fham.inner.to_majorana_sparse();
+        let (mut hamiltonian, operator_n_modes) = match operator {
+            EncodeInput::Fermion(fham) => (fham.inner.to_majorana_sparse(), fham.inner.n_modes()),
+            EncodeInput::Majorana(msparse) => (msparse.inner.clone(), msparse.n_modes),
+        };
         hamiltonian.constant = 0.0;
-        let temperature = temperature.unwrap_or(fham.inner.n_modes() as f64);
+        let temperature = temperature.unwrap_or(operator_n_modes as f64);
         let initial_guess =
             Array1::from(initial_guess.unwrap_or_else(|| (0..self.0.n_modes).collect()));
         let params = AnnealingParameters::new(temperature, 1000, seed.unwrap_or(1017));
@@ -669,7 +668,10 @@ impl PyMajoranaEncoding {
     /// mode permutations in a single parallelised call.
     ///
     /// Args:
-    ///     fham: The fermionic Hamiltonian to weigh.
+    ///     operator: The operator to weigh, either a ``FermionHamiltonian`` or a
+    ///         ``MajoranaSparse``. A ``FermionHamiltonian`` is converted to its
+    ///         Majorana representation first; passing a ``MajoranaSparse``
+    ///         directly skips that conversion.
     ///     permutations: 2D uint array of shape ``(n_perms, n_modes)``.
     ///
     /// Returns:
@@ -678,10 +680,13 @@ impl PyMajoranaEncoding {
     fn batch_pauli_weights<'py>(
         &self,
         py: Python<'py>,
-        fham: PyRef<'_, PyFermionHamiltonian>,
+        operator: EncodeInput<'_>,
         permutations: PyReadonlyArray2<'py, usize>,
     ) -> Result<(Bound<'py, PyArray1<f64>>, Bound<'py, PyArray1<f64>>), CoreError> {
-        let mut hamiltonian = fham.inner.to_majorana_sparse();
+        let mut hamiltonian = match operator {
+            EncodeInput::Fermion(fham) => fham.inner.to_majorana_sparse(),
+            EncodeInput::Majorana(msparse) => msparse.inner.clone(),
+        };
         hamiltonian.constant = 0.0;
         let perms: Vec<Vec<usize>> = permutations
             .as_array()

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -21,7 +21,7 @@ use pyo3::types::{PyComplex, PyInt, PyString};
 /// Apply γ²=1 simplification, merge duplicate Majorana keys, and drop
 /// terms whose summed coefficient falls below the near-zero threshold.
 ///
-/// Both `FermionHamiltonian.to_sparse_majorana` and `hatt` consume the result;
+/// Both `MajoranaSparse.to_dict()` and `hatt` consume the result;
 /// going through a single helper guarantees they see identical term sets
 /// (a per-entry accumulate-and-filter loop can leave stale entries when a
 /// running coefficient cancels below the threshold).

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1,8 +1,8 @@
 //! Free functions exposed in the `ferrmion.core` module.
 
-use crate::encoding::PyMajoranaEncoding;
+use crate::encoding::{EncodeInput, PyMajoranaEncoding};
 use crate::error::CoreError;
-use crate::hamiltonians::{PyFermionHamiltonian, PyQubitHamiltonian};
+use crate::hamiltonians::PyQubitHamiltonian;
 use crate::operators::PyMajoranaSparse;
 use ferrmion_core::encode::majorana::Encode;
 use ferrmion_core::encode::ternarytree::{TTFlatpack, TernaryTree};
@@ -183,23 +183,30 @@ pub(crate) fn symplectic_to_sparse<'py>(
 /// from scratch.
 ///
 /// Args:
-///     fham: The fermionic Hamiltonian whose terms drive the greedy search.
-///     `n_modes`: Number of fermionic modes. Defaults to ``fham.n_modes``.
+///     operator: The operator whose terms drive the greedy search, either a
+///         ``FermionHamiltonian`` or a ``MajoranaSparse``. A
+///         ``FermionHamiltonian`` is converted to its Majorana representation
+///         first; passing a ``MajoranaSparse`` directly skips that conversion.
+///     `n_modes`: Number of fermionic modes. Defaults to the operator's own
+///         mode count.
 ///
 /// Returns:
 ///     Tuple of ``(flatpack, total_pauli_weight)`` where ``flatpack`` is
 ///     the ternary-tree flatpack representation and the weight is the
 ///     total Pauli weight of the greedy selections.
 #[pyfunction(name = "hatt")]
-#[pyo3(signature = (fham, n_modes = None))]
+#[pyo3(signature = (operator, n_modes = None))]
 pub(crate) fn hatt_py(
     py: Python<'_>,
-    fham: PyRef<'_, PyFermionHamiltonian>,
+    operator: EncodeInput<'_>,
     n_modes: Option<usize>,
 ) -> Result<(TTFlatpack, usize), CoreError> {
     debug!("Starting HATT");
-    let n_modes = n_modes.unwrap_or(fham.inner.n_modes());
-    let mut hamiltonian = fham.inner.to_majorana_sparse();
+    let (mut hamiltonian, operator_n_modes) = match operator {
+        EncodeInput::Fermion(fham) => (fham.inner.to_majorana_sparse(), fham.inner.n_modes()),
+        EncodeInput::Majorana(msparse) => (msparse.inner.clone(), msparse.n_modes),
+    };
+    let n_modes = n_modes.unwrap_or(operator_n_modes);
     hamiltonian.constant = 0.0;
     let (tree, weight) = py.allow_threads(|| -> Result<_, CoreError> {
         let simplified_terms: Vec<tinyvec::ArrayVec<[u16; 7]>> =
@@ -288,12 +295,12 @@ pub(crate) fn topphatt_py(
     backend: &str,
 ) -> Result<PyMajoranaEncoding, CoreError> {
     debug!("Starting TOPPHATT");
-    // let mut hamiltonian = hamiltonian.0;
+    // let mut hamiltonian = hamiltonian.inner;
     // hamiltonian.constant = 0.0;
 
     let encoding = py.allow_threads(|| -> Result<_, CoreError> {
         let tree = run_topphatt(
-            hamiltonian.0,
+            hamiltonian.inner,
             flatpack,
             parallelize,
             heuristic,
@@ -312,7 +319,10 @@ pub(crate) fn topphatt_py(
 /// Args:
 ///     flatpack: List of ``(qubit_index, (left, mid, right))`` tuples — initial tree.
 ///     `n_qubits`: Total number of qubits in the system.
-///     fham: The fermionic Hamiltonian to optimise for and encode.
+///     operator: The operator to optimise for and encode, either a
+///         ``FermionHamiltonian`` or a ``MajoranaSparse``. A
+///         ``FermionHamiltonian`` is converted to its Majorana representation
+///         first; passing a ``MajoranaSparse`` directly skips that conversion.
 ///     parallelize: If ``True``, use multi-threaded evaluation via Rayon.
 ///     heuristic: Node-selection strategy. One of ``"min_weight"``
 ///         (default), ``"x_first"``, ``"z_first"``, or ``"random"``.
@@ -323,13 +333,13 @@ pub(crate) fn topphatt_py(
 /// Returns:
 ///     Tuple of ``(QubitHamiltonian, MajoranaEncoding)``.
 #[pyfunction(name = "encode_topphatt")]
-#[pyo3(signature = (flatpack, n_qubits, fham, parallelize = true, heuristic = "min_weight", seed = None, backend = "dense_transpose"))]
+#[pyo3(signature = (flatpack, n_qubits, operator, parallelize = true, heuristic = "min_weight", seed = None, backend = "dense_transpose"))]
 #[allow(clippy::too_many_arguments)] // signature mirrors the Python API
 pub(crate) fn encode_topphatt_py(
     py: Python<'_>,
     flatpack: TTFlatpack,
     n_qubits: usize,
-    fham: PyRef<'_, PyFermionHamiltonian>,
+    operator: EncodeInput<'_>,
     parallelize: bool,
     heuristic: &str,
     seed: Option<u64>,
@@ -337,7 +347,10 @@ pub(crate) fn encode_topphatt_py(
 ) -> Result<(PyQubitHamiltonian, PyMajoranaEncoding), CoreError> {
     debug!("Starting TOPPHATT");
     // let heuristic = NodeOrderHeuristic::parse(heuristic, seed).map_err(CoreError::Value)?;
-    let hamiltonian = fham.inner.to_majorana_sparse();
+    let hamiltonian = match operator {
+        EncodeInput::Fermion(fham) => fham.inner.to_majorana_sparse(),
+        EncodeInput::Majorana(msparse) => msparse.inner.clone(),
+    };
 
     let (qham, encoding) = py.allow_threads(|| -> Result<_, CoreError> {
         let tree = run_topphatt(

--- a/src/hamiltonians.rs
+++ b/src/hamiltonians.rs
@@ -1,7 +1,6 @@
 //! `pyclass` wrappers for the core Hamiltonian types.
 
 use crate::error::CoreError;
-use crate::functions::simplified_majorana_terms;
 use crate::operators::PyMajoranaSparse;
 use ferrmion_core::hamiltonians::{FermionHamiltonian, QubitHamiltonian, SymplecticHamiltonian};
 use ferrmion_core::operators::{CoefficientPauliWeight, PauliWeight};
@@ -379,19 +378,6 @@ impl PyFermionHamiltonian {
             coeffs.push(term.coefficients().to_owned().into_pyarray(py));
         }
         (sigs, coeffs)
-    }
-
-    /// Convert to a sparse Majorana representation.
-    ///
-    /// Returns:
-    ///     Dictionary mapping tuples of Majorana indices to complex coefficients.
-    fn to_sparse_majorana<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
-        let hamiltonian = self.inner.to_majorana_sparse();
-        let output = PyDict::new(py);
-        for (key, val) in simplified_majorana_terms(hamiltonian) {
-            output.set_item(PyTuple::new(py, key.as_slice())?, val)?;
-        }
-        Ok(output)
     }
 
     /// Convert to a sparse Majorana representation.

--- a/src/hamiltonians.rs
+++ b/src/hamiltonians.rs
@@ -385,7 +385,10 @@ impl PyFermionHamiltonian {
     /// Returns:
     ///     `MajoranaSparse`: The sparse Majorana representation of this Hamiltonian.
     fn to_majorana_sparse(&self) -> PyMajoranaSparse {
-        PyMajoranaSparse(self.inner.to_majorana_sparse())
+        PyMajoranaSparse {
+            inner: self.inner.to_majorana_sparse(),
+            n_modes: self.inner.n_modes(),
+        }
     }
 
     fn __eq__(&self, other: &Bound<'_, PyAny>) -> bool {

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -12,14 +12,23 @@ use pyo3::types::{PyDict, PyTuple};
 /// Instances are obtained via `FermionHamiltonian.to_majorana_sparse()`.
 #[pyclass(name = "MajoranaSparse", module = "ferrmion.core")]
 #[derive(Clone, Debug)]
-pub struct PyMajoranaSparse(pub MajoranaSparse);
+pub struct PyMajoranaSparse {
+    pub inner: MajoranaSparse,
+    /// Mode count of the `FermionHamiltonian` this was converted from.
+    ///
+    /// The core `MajoranaSparse` carries no mode count of its own, so this is
+    /// tracked here to let Python-facing methods that need a mode count
+    /// (e.g. defaulting `hatt`'s `n_modes` or `encode_annealed`'s
+    /// `temperature`) work without requiring the caller to pass it explicitly.
+    pub n_modes: usize,
+}
 
 #[pymethods]
 impl PyMajoranaSparse {
     /// The Majorana indices of each term, as a list of lists.
     #[getter]
     fn indices(&self) -> Vec<Vec<u16>> {
-        self.0
+        self.inner
             .indices
             .iter()
             .map(|term| term.as_slice().to_vec())
@@ -29,33 +38,40 @@ impl PyMajoranaSparse {
     /// The complex coefficient of each term.
     #[getter]
     fn coefficients<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<Complex64>> {
-        self.0.coefficients.clone().into_pyarray(py)
+        self.inner.coefficients.clone().into_pyarray(py)
     }
 
     /// The constant (identity) term of the Hamiltonian.
     #[getter]
     fn constant(&self) -> f64 {
-        self.0.constant
+        self.inner.constant
+    }
+
+    /// The mode count of the `FermionHamiltonian` this was converted from.
+    #[getter]
+    fn n_modes(&self) -> usize {
+        self.n_modes
     }
 
     fn __eq__(&self, other: &Bound<'_, PyAny>) -> bool {
         other
             .extract::<PyRef<'_, Self>>()
-            .is_ok_and(|o| self.0 == o.0)
+            .is_ok_and(|o| self.inner == o.inner && self.n_modes == o.n_modes)
     }
 
     fn __repr__(&self) -> String {
         format!(
-            "MajoranaSparse({} terms, constant {})",
-            self.0.indices.len(),
-            self.0.constant
+            "MajoranaSparse({} terms, constant {}, n_modes {})",
+            self.inner.indices.len(),
+            self.inner.constant,
+            self.n_modes
         )
     }
 
     /// Convert to a dictionary mapping Majorana index tuples to coefficients.
     /// Simplified by removing paired adjacent indices.
     fn to_dict<'py>(&self, py: Python<'py>) -> Bound<'py, PyDict> {
-        let simplified = simplified_majorana_terms(self.0.clone());
+        let simplified = simplified_majorana_terms(self.inner.clone());
         let output = PyDict::new(py);
         for (key, val) in simplified {
             let key_tuple = PyTuple::new(py, key.as_slice()).unwrap();

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -1,8 +1,10 @@
 //! `pyclass` wrapper for the core [`MajoranaSparse`] type.
 
+use crate::functions::simplified_majorana_terms;
 use ferrmion_core::operators::MajoranaSparse;
 use numpy::{Complex64, IntoPyArray, PyArray1};
 use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyTuple};
 
 /// A sparse representation of a Hamiltonian as a sum of Majorana operator
 /// products, backed by the Rust [`MajoranaSparse`] type.
@@ -48,5 +50,17 @@ impl PyMajoranaSparse {
             self.0.indices.len(),
             self.0.constant
         )
+    }
+
+    /// Convert to a dictionary mapping Majorana index tuples to coefficients.
+    /// Simplified by removing paired adjacent indices.
+    fn to_dict<'py>(&self, py: Python<'py>) -> Bound<'py, PyDict> {
+        let simplified = simplified_majorana_terms(self.0.clone());
+        let output = PyDict::new(py);
+        for (key, val) in simplified {
+            let key_tuple = PyTuple::new(py, key.as_slice()).unwrap();
+            let _ = output.set_item(key_tuple, val);
+        }
+        output
     }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -629,7 +629,7 @@ wheels = [
 
 [[package]]
 name = "ferrmion"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "deap" },


### PR DESCRIPTION
Some functions forgotten in #216 , and deleting a confusingly similar `to_sparse_majorana` which I had forgotten about .